### PR TITLE
Ensure drawing backgrounds load when opening map

### DIFF
--- a/lib/util/drawing_image_loader.dart
+++ b/lib/util/drawing_image_loader.dart
@@ -1,0 +1,34 @@
+import 'dart:typed_data';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import '../model/drawing.dart';
+import '../provider/drawing_provider.dart';
+
+/// Base path for bundled drawing images.
+const String kDrawingImageAssetPath = 'lib/asset/locationmap/';
+
+/// Mapping from drawing id to asset file name.
+///
+/// When more drawings are added, register the corresponding file here.
+const Map<String, String> kDrawingImageFiles = {
+  'D1': 'conco_11F_A.jpg',
+  // Add additional mappings like 'D2': 'some_file.jpg'
+};
+
+/// Ensures that [drawing] has its background image loaded.
+///
+/// If the image bytes are already present this function does nothing. When the
+/// image is missing and an asset file is registered for the drawing id, the
+/// bytes are loaded from the bundle and stored via [DrawingProvider].
+Future<void> loadDrawingImageIfNeeded(DrawingProvider dp, Drawing drawing) async {
+  if (drawing.imageBytes != null && drawing.imageBytes!.isNotEmpty) return;
+  final fileName = kDrawingImageFiles[drawing.id];
+  if (fileName == null) return;
+  try {
+    final ByteData data = await rootBundle.load('$kDrawingImageAssetPath$fileName');
+    final Uint8List bytes = data.buffer.asUint8List();
+    await dp.setImageBytes(id: drawing.id, bytes: bytes, fileName: fileName);
+  } catch (e) {
+    debugPrint('Failed to load drawing image: $e');
+  }
+}

--- a/lib/view/drawing/drawing_map_screen.dart
+++ b/lib/view/drawing/drawing_map_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import '../../provider/drawing_provider.dart';
 import '../../provider/asset_provider.dart';
 import '../../model/drawing.dart';
+import '../../util/drawing_image_loader.dart';
 
 // (선택) 격자/테두리 색만 모아두고 싶다면 상수로 둡니다.
 const _kGridColor = Color(0x18000000);   // 검정(연한)
@@ -24,6 +25,16 @@ class _DrawingMapScreenState extends State<DrawingMapScreen> {
   // ✅ 배율 상태(드롭다운)
   double _scale = 1.0;
   final List<double> _scaleOptions = [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.25, 2.5, 3.0];
+
+  @override
+  void initState() {
+    super.initState();
+    final dp = context.read<DrawingProvider>();
+    final d = dp.getById(widget.drawingId);
+    if (d != null) {
+      loadDrawingImageIfNeeded(dp, d);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/view/drawing/drawing_screen.dart
+++ b/lib/view/drawing/drawing_screen.dart
@@ -1,12 +1,11 @@
 // lib/view/drawing/drawing_screen.dart
-import 'dart:typed_data';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show rootBundle;
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../provider/drawing_provider.dart';
 import '../../model/drawing.dart';
+import '../../util/drawing_image_loader.dart';
 
 /// 도면 목록 화면
 /// - "열기" 버튼을 누르면:
@@ -14,11 +13,6 @@ import '../../model/drawing.dart';
 ///   2) 맵 화면(/drawing/:id/map)으로 이동 → 배경 + 격자 표시
 class DrawingScreen extends StatelessWidget {
   const DrawingScreen({super.key});
-
-  // 👉 현재 요구대로 고정 파일명 사용. 나중에 항목별로 다르게 하고 싶으면
-  //    d.building/floor/title 등을 조합해서 파일명을 만들면 된다.
-  static const String kMapImageFileName = 'conco_11F_A.jpg';
-  static const String kMapImageAssetPath = 'lib/asset/locationmap/';
 
   @override
   Widget build(BuildContext context) {
@@ -59,11 +53,11 @@ class DrawingScreen extends StatelessWidget {
                           children: [
                             OutlinedButton.icon(
                               icon: const Icon(Icons.image),
-                              label: const Text('열기'),// (열기 버튼) 배경 적용 후 맵 이동
+                              label: const Text('열기'), // 배경 적용 후 맵 이동
                               onPressed: () async {
-                                await _applyBackgroundFromAsset(context, d);
+                                await loadDrawingImageIfNeeded(dp, d);
                                 if (context.mounted) {
-                                  context.push('/drawing/${d.id}/map'); // ✅ pushNamed → push (go_router)
+                                  context.push('/drawing/${d.id}/map');
                                 }
                               },
                             ),
@@ -86,30 +80,6 @@ class DrawingScreen extends StatelessWidget {
     );
   }
 
-  /// lib/asset/locationmap/<kMapImageFileName> 를 읽어와서
-  /// DrawingProvider에 이미지 바이트를 설정한다.
-  Future<void> _applyBackgroundFromAsset(BuildContext context, Drawing d) async {
-    final dp = context.read<DrawingProvider>();
-
-    try {
-      final String assetPath = '$kMapImageAssetPath$kMapImageFileName';
-
-      // assets 에 등록된 파일에서 바이트 로드
-      final ByteData data = await rootBundle.load(assetPath);
-      final Uint8List bytes = data.buffer.asUint8List();
-
-      // Provider에 이미지 적용 (아래 메서드명은 기존 구현에 맞춰 사용)
-      // - 만약 setImageBytes가 없다면, DrawingProvider에 해당 메서드를 추가해 주세요.
-      //   예) Future<void> setImageBytes({required String id, required Uint8List bytes})
-      await dp.setImageBytes(id: d.id, bytes: bytes);
-    } catch (e) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('배경 이미지 로드 실패: $e')),
-        );
-      }
-    }
-  }
 }
 
 class _Legend extends StatelessWidget {

--- a/lib/view/screen/asset_detail_screen.dart
+++ b/lib/view/screen/asset_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../../provider/asset_provider.dart';
 import '../../provider/drawing_provider.dart';
 import 'package:go_router/go_router.dart';
+import '../../util/drawing_image_loader.dart';
 
 class AssetDetailScreen extends StatelessWidget {
   const AssetDetailScreen({super.key, required this.id});
@@ -41,9 +42,15 @@ class AssetDetailScreen extends StatelessWidget {
             children: [
               if (hasLoc)
                 FilledButton.icon(
-                  onPressed: () {
-                    // 해당 도면으로 이동
-                    context.push('/drawing/${asset.locationDrawingId}/map');
+                  onPressed: () async {
+                    // 도면 배경이 없으면 로드 후 이동
+                    final d = dp.getById(asset.locationDrawingId!);
+                    if (d != null) {
+                      await loadDrawingImageIfNeeded(dp, d);
+                    }
+                    if (context.mounted) {
+                      context.push('/drawing/${asset.locationDrawingId}/map');
+                    }
                   },
                   icon: const Icon(Icons.map),
                   label: const Text('도면에서 보기'),


### PR DESCRIPTION
## Summary
- Added `drawing_image_loader` utility to map drawing IDs to bundled images
- Preload drawing background in asset detail before navigation
- Load images lazily in map and drawing list screens

## Testing
- `dart format lib/util/drawing_image_loader.dart lib/view/drawing/drawing_screen.dart lib/view/drawing/drawing_map_screen.dart lib/view/screen/asset_detail_screen.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c570423784832294239eaada155793