### PR TITLE
Allow assets to specify drawing background

### DIFF
--- a/lib/model/asset.dart
+++ b/lib/model/asset.dart
@@ -1,4 +1,7 @@
 // lib/model/asset.dart
+
+const _unset = Object();
+
 class Asset {
   /// 오름차순 순번 (문자열로 보관하지만 "1","2","3"... 형태)
   final String id;
@@ -25,6 +28,8 @@ class Asset {
   String? locationDrawingId;
   int? locationRow;
   int? locationCol;
+  /// 도면 파일명(배경)
+  String? locationDrawingFile;
 
   DateTime createdAt;
   DateTime updatedAt;
@@ -40,6 +45,7 @@ class Asset {
     this.locationDrawingId,
     this.locationRow,
     this.locationCol,
+    this.locationDrawingFile,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -54,6 +60,7 @@ class Asset {
     String? locationDrawingId,
     int? locationRow,
     int? locationCol,
+    Object? locationDrawingFile = _unset,
     DateTime? createdAt,
     DateTime? updatedAt,
   }) {
@@ -68,6 +75,9 @@ class Asset {
       locationDrawingId: locationDrawingId ?? this.locationDrawingId,
       locationRow: locationRow ?? this.locationRow,
       locationCol: locationCol ?? this.locationCol,
+      locationDrawingFile: locationDrawingFile == _unset
+          ? this.locationDrawingFile
+          : locationDrawingFile as String?,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );

--- a/lib/provider/asset_provider.dart
+++ b/lib/provider/asset_provider.dart
@@ -26,6 +26,7 @@ class AssetProvider extends ChangeNotifier {
     required String? drawingId, // null이면 위치 해제
     int? row,
     int? col,
+    String? drawingFile,
     required DrawingProvider drawingProvider,
   }) async {
     // 기존 위치(제거 목적)
@@ -37,6 +38,7 @@ class AssetProvider extends ChangeNotifier {
       drawingId: drawingId,
       row: row,
       col: col,
+      drawingFile: drawingFile ?? (drawingId == null ? null : before?.locationDrawingFile),
     );
     items = repo.list();
     notifyListeners();

--- a/lib/repository/asset_repository.dart
+++ b/lib/repository/asset_repository.dart
@@ -1,6 +1,7 @@
 // lib/repository/asset_repository.dart
 import 'dart:math';
 import '../model/asset.dart';
+import '../util/drawing_image_loader.dart' show kDrawingImageFiles;
 
 class AssetRepository {
   final List<Asset> _items = [];
@@ -34,6 +35,7 @@ class AssetRepository {
     String? drawingId,
     int? row,
     int? col,
+    String? drawingFile,
   }) {
     final idx = _items.indexWhere((e) => e.id == id);
     if (idx < 0) return null;
@@ -42,6 +44,7 @@ class AssetRepository {
       locationDrawingId: drawingId,
       locationRow: row,
       locationCol: col,
+      locationDrawingFile: drawingFile,
       updatedAt: now,
     );
     return _items[idx];
@@ -139,6 +142,7 @@ class AssetRepository {
         locationDrawingId: drawId,
         locationRow: row,
         locationCol: col,
+        locationDrawingFile: drawId == null ? null : kDrawingImageFiles[drawId],
         createdAt: created,
         updatedAt: updated,
       ));

--- a/lib/util/drawing_image_loader.dart
+++ b/lib/util/drawing_image_loader.dart
@@ -18,16 +18,21 @@ const Map<String, String> kDrawingImageFiles = {
 /// Ensures that [drawing] has its background image loaded.
 ///
 /// If the image bytes are already present this function does nothing. When the
-/// image is missing and an asset file is registered for the drawing id, the
-/// bytes are loaded from the bundle and stored via [DrawingProvider].
-Future<void> loadDrawingImageIfNeeded(DrawingProvider dp, Drawing drawing) async {
+/// image is missing and an asset file is registered for the drawing id or
+/// supplied via [fileName], the bytes are loaded from the bundle and stored via
+/// [DrawingProvider].
+Future<void> loadDrawingImageIfNeeded(
+  DrawingProvider dp,
+  Drawing drawing, {
+  String? fileName,
+}) async {
   if (drawing.imageBytes != null && drawing.imageBytes!.isNotEmpty) return;
-  final fileName = kDrawingImageFiles[drawing.id];
-  if (fileName == null) return;
+  final name = fileName ?? kDrawingImageFiles[drawing.id];
+  if (name == null) return;
   try {
-    final ByteData data = await rootBundle.load('$kDrawingImageAssetPath$fileName');
+    final ByteData data = await rootBundle.load('$kDrawingImageAssetPath$name');
     final Uint8List bytes = data.buffer.asUint8List();
-    await dp.setImageBytes(id: drawing.id, bytes: bytes, fileName: fileName);
+    await dp.setImageBytes(id: drawing.id, bytes: bytes, fileName: name);
   } catch (e) {
     debugPrint('Failed to load drawing image: $e');
   }

--- a/lib/view/screen/asset_detail_screen.dart
+++ b/lib/view/screen/asset_detail_screen.dart
@@ -43,10 +43,14 @@ class AssetDetailScreen extends StatelessWidget {
               if (hasLoc)
                 FilledButton.icon(
                   onPressed: () async {
-                    // 도면 배경이 없으면 로드 후 이동
+                    // 도면 배경이 없으면 자산에 지정된 파일을 로드 후 이동
                     final d = dp.getById(asset.locationDrawingId!);
                     if (d != null) {
-                      await loadDrawingImageIfNeeded(dp, d);
+                      await loadDrawingImageIfNeeded(
+                        dp,
+                        d,
+                        fileName: asset.locationDrawingFile,
+                      );
                     }
                     if (context.mounted) {
                       context.push('/drawing/${asset.locationDrawingId}/map');
@@ -117,11 +121,13 @@ class _LocationDialogState extends State<_LocationDialog> {
   String? _drawingId;
   final _row = TextEditingController(text: '0');
   final _col = TextEditingController(text: '0');
+  final _file = TextEditingController();
 
   @override
   void dispose() {
     _row.dispose();
     _col.dispose();
+    _file.dispose();
     super.dispose();
   }
 
@@ -147,6 +153,11 @@ class _LocationDialogState extends State<_LocationDialog> {
               ))
                   .toList(),
               onChanged: (v) => setState(() => _drawingId = v),
+            ),
+            const SizedBox(height: 8),
+            TextFormField(
+              controller: _file,
+              decoration: const InputDecoration(labelText: '도면 파일명'),
             ),
             const SizedBox(height: 8),
             Row(
@@ -187,6 +198,7 @@ class _LocationDialogState extends State<_LocationDialog> {
               drawingId: _drawingId,
               row: _drawingId == null ? null : r,
               col: _drawingId == null ? null : c,
+              drawingFile: _file.text.isEmpty ? null : _file.text,
               drawingProvider: context.read<DrawingProvider>(),
             );
             if (context.mounted) Navigator.pop(context);


### PR DESCRIPTION
## Summary
- Add `locationDrawingFile` to `Asset` model and persist through repository and provider
- Enable loading map background from asset-specified file when viewing drawing
- Allow location dialog to set drawing file name

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c577823a5083228cc0e0bacee8f05e