### PR TITLE
feat: extend asset model and add building/user metadata

### DIFF
--- a/lib/model/asset.dart
+++ b/lib/model/asset.dart
@@ -24,6 +24,33 @@ class Asset {
   /// 공급사/제조사
   String vendor;
 
+  /// 네트워크 구분
+  String? network;
+
+  /// 실물 점검일
+  DateTime? physicalCheckDate;
+
+  /// 검수일자
+  DateTime? confirmationDate;
+
+  /// 일반 비고 (100자 이내)
+  String? normalComment;
+
+  /// OA 비고 (100자 이내)
+  String? oaComment;
+
+  /// MAC 주소
+  String? macAddress;
+
+  /// 건물명(선택)
+  String? building;
+
+  /// 층(선택)
+  String? floor;
+
+  /// 담당자명(선택)
+  String? memberName;
+
   /// 위치(선택)
   String? locationDrawingId;
   int? locationRow;
@@ -42,6 +69,15 @@ class Asset {
     required this.serialNumber,
     required this.modelName,
     required this.vendor,
+    this.network,
+    this.physicalCheckDate,
+    this.confirmationDate,
+    this.normalComment,
+    this.oaComment,
+    this.macAddress,
+    this.building,
+    this.floor,
+    this.memberName,
     this.locationDrawingId,
     this.locationRow,
     this.locationCol,
@@ -57,6 +93,15 @@ class Asset {
     String? serialNumber,
     String? modelName,
     String? vendor,
+    String? network,
+    DateTime? physicalCheckDate,
+    DateTime? confirmationDate,
+    String? normalComment,
+    String? oaComment,
+    String? macAddress,
+    String? building,
+    String? floor,
+    String? memberName,
     String? locationDrawingId,
     int? locationRow,
     int? locationCol,
@@ -72,6 +117,15 @@ class Asset {
       serialNumber: serialNumber ?? this.serialNumber,
       modelName: modelName ?? this.modelName,
       vendor: vendor ?? this.vendor,
+      network: network ?? this.network,
+      physicalCheckDate: physicalCheckDate ?? this.physicalCheckDate,
+      confirmationDate: confirmationDate ?? this.confirmationDate,
+      normalComment: normalComment ?? this.normalComment,
+      oaComment: oaComment ?? this.oaComment,
+      macAddress: macAddress ?? this.macAddress,
+      building: building ?? this.building,
+      floor: floor ?? this.floor,
+      memberName: memberName ?? this.memberName,
       locationDrawingId: locationDrawingId ?? this.locationDrawingId,
       locationRow: locationRow ?? this.locationRow,
       locationCol: locationCol ?? this.locationCol,

--- a/lib/model/buildingPic.dart
+++ b/lib/model/buildingPic.dart
@@ -1,0 +1,34 @@
+// lib/model/buildingPic.dart
+
+/// 건물 · 층 · 도면 배경 파일 정보를 보관하는 간단한 모델
+class BuildingPic {
+  final String? buildingName; // 건물명 (없을 수 있음)
+  final String floor;        // 층 (예: B1, F1)
+  final String? bgFile;      // 배경 이미지 파일명
+
+  const BuildingPic({this.buildingName, required this.floor, this.bgFile});
+}
+
+/// 사용 가능한 건물명 목록
+const List<String?> buildingNames = [
+  '콘코디언',
+  '한경경제신문사',
+  '본사',
+  '센터',
+  'CRM',
+  null,
+];
+
+/// 사용 가능한 층 목록
+const List<String> floorList = [
+  'B7', 'B6', 'B5', 'B4', 'B3', 'B2', 'B1', 'L',
+  'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10',
+  'F11', 'F12', 'F13', 'F14', 'F15', 'F16', 'F17', 'F18', 'F19', 'F20', 'F21', 'F22',
+];
+
+/// 도면 배경 파일명 목록
+const List<String?> buildingBgFiles = [
+  'hankyung_16F_A.png',
+  'conco_11F_A.jpg',
+  null,
+];

--- a/lib/model/user.dart
+++ b/lib/model/user.dart
@@ -1,0 +1,93 @@
+// lib/model/user.dart
+
+/// 임직원 정보를 표현하는 모델
+class User {
+  final int no; // 오름차순 순번
+  final String employeeId; // 고유 아이디 (B/P/A + 6자리 숫자)
+  final String employeeName; // 이름
+  final String? orgNameHq; // 본부
+  final String? orgNameDept; // 실/부서
+  final String? orgNameTeam; // 팀
+  final String? orgNamePart; // 파트/업무
+  final String? orgNameEtc; // 기타 직책
+  final String? workLocationBuilding; // 근무 건물
+  final String? workLocationFloor; // 근무 층
+
+  const User({
+    required this.no,
+    required this.employeeId,
+    required this.employeeName,
+    this.orgNameHq,
+    this.orgNameDept,
+    this.orgNameTeam,
+    this.orgNamePart,
+    this.orgNameEtc,
+    this.workLocationBuilding,
+    this.workLocationFloor,
+  });
+}
+
+/// 사원 이름 목록 (자산의 memberName과 연결)
+const List<String> employeeNames = [
+  '차두리',
+  '강남길',
+  '김유정',
+  '김소연',
+];
+
+/// 조직명 목록들
+const List<String?> orgNameHqList = [
+  '개발본부',
+  '영업본부',
+  '기획본부',
+  '운영본부',
+  '마케팅본부',
+  null,
+];
+
+const List<String?> orgNameDeptList = [
+  '개발1실',
+  '개발2실',
+  '영업1실',
+  '영업2실',
+  '기획1실',
+  '기획2실',
+  '운영1실',
+  '운영2실',
+  '마케팅1실',
+  '마케팅2실',
+  null,
+];
+
+const List<String?> orgNameTeamList = [
+  '프론트개발팀',
+  '백엔드개발팀',
+  '해외영업팀',
+  '국내영업팀',
+  '구매기획팀',
+  '운영기획팀',
+  'IT운영1팀',
+  'IT운영2팀',
+  '직작인마케팅팀',
+  '학생마케팅팀',
+  '음악인마케팅팀',
+  '은퇴자마케팅팀',
+  null,
+];
+
+const List<String?> orgNamePartList = [
+  '콜업무',
+  '추심업무',
+  '제작업무',
+  '영업업무',
+  '고객응대업무',
+  null,
+];
+
+const List<String?> orgNameEtcList = [
+  '대표이사',
+  '감사',
+  '소비자보호',
+  '고문',
+  null,
+];

--- a/lib/provider/asset_provider.dart
+++ b/lib/provider/asset_provider.dart
@@ -20,6 +20,13 @@ class AssetProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  Asset? update(Asset a) {
+    final updated = repo.update(a);
+    items = repo.list();
+    notifyListeners();
+    return updated;
+  }
+
   // 자산 위치 변경 + 도면 셀에 동기화
   Future<Asset?> setLocationAndSync({
     required String assetId,

--- a/lib/repository/asset_repository.dart
+++ b/lib/repository/asset_repository.dart
@@ -1,14 +1,15 @@
 // lib/repository/asset_repository.dart
 import 'dart:math';
 import '../model/asset.dart';
-import '../util/drawing_image_loader.dart' show kDrawingImageFiles;
+import '../model/buildingPic.dart';
+import '../model/user.dart';
 
 class AssetRepository {
   final List<Asset> _items = [];
   int _idCounter = 0; // 오름차순 순번
 
   AssetRepository() {
-    _seed10();
+    _seed20();
   }
 
   // ───────────────────────────────────────────────────────────
@@ -53,11 +54,17 @@ class AssetRepository {
   // ───────────────────────────────────────────────────────────
   // Seed & Helpers
 
-  void _seed10() {
+  void _seed20() {
     final rnd = Random();
     final vendors = ['Samsung', 'LG', 'Siemens', 'FANUC', 'Omron', 'Keyence', 'Bosch', 'Panasonic'];
     final models  = ['X100', 'M450', 'S2-Pro', 'VX-9', 'HF-220', 'Prime-7', 'Neo-3', 'Edge-11'];
-    final cats    = ['생산설비', 'IT장비', '품질장비', '공용비품', '안전설비'];
+    final cats2   = ['생산설비', 'IT장비', '품질장비', '공용비품', '안전설비'];
+    final cats1   = ['모니터', '프린터', '데스크탑', '노트북', '태블릿', '스캐너', 'Test폰', '기타'];
+    final networks = ['업무망', '개발망', '시스템망', '인터넷망', null];
+    const buildings = buildingNames;
+    const floors = floorList;
+    const List<String?> bgFiles = buildingBgFiles;
+    final members = [...employeeNames, null];
 
     // 최근 365일 내 랜덤 생성일
     DateTime _randCreated() {
@@ -101,35 +108,47 @@ class AssetRepository {
       return _idCounter.toString();
     }
 
-    // 샘플 10개
+    // 기본 10개 프리셋
     final presets = [
-      ('프레스기 A', '생산설비', 'D7', 2, 3),
-      ('프레스기 B', '생산설비', 'D8', 4, 7),
-      ('컨베이어 1호', '생산설비', 'D5', 1, 5),
-      ('스위치 24P',  'IT장비',  'D7', 0, 10),
-      ('무선 AP-동측', 'IT장비', 'D7', 3, 2),
-      ('마이크로미터', '품질장비', null, null, null),
-      ('캘리퍼스',     '품질장비', 'D8', 6, 8),
-      ('냉장고',       '공용비품', null, null, null),
-      ('에어컨-사무동', '공용비품', 'D8', 2, 14),
-      ('소화전 펌프',  '안전설비', 'D8', 10, 10),
+      ('프레스기 A', '생산설비'),
+      ('프레스기 B', '생산설비'),
+      ('컨베이어 1호', '생산설비'),
+      ('스위치 24P', 'IT장비'),
+      ('무선 AP-동측', 'IT장비'),
+      ('마이크로미터', '품질장비'),
+      ('캘리퍼스', '품질장비'),
+      ('냉장고', '공용비품'),
+      ('에어컨-사무동', '공용비품'),
+      ('소화전 펌프', '안전설비'),
     ];
 
     for (final p in presets) {
-      final id     = _nextId();
-      final code   = _genCode();
-      final name   = p.$1;
-      final cat    = p.$2;
-      final drawId = p.$3;
-      final row    = p.$4;
-      final col    = p.$5;
-
+      final id = _nextId();
+      final code = _genCode();
+      final name = p.$1;
+      final cat = p.$2;
       final vendor = vendors[rnd.nextInt(vendors.length)];
-      final model  = models[rnd.nextInt(models.length)];
-      final sn     = _serial();
-
+      final model = models[rnd.nextInt(models.length)];
+      final sn = _serial();
+      final building = buildings[rnd.nextInt(buildings.length)];
+      final floor = floors[rnd.nextInt(floors.length)];
+      final member = members[rnd.nextInt(members.length)];
+      final drawFile = bgFiles[rnd.nextInt(bgFiles.length)];
+      final drawId = drawFile == null ? null : 'D${1 + rnd.nextInt(8)}';
+      final row = drawFile == null ? null : rnd.nextInt(10);
+      final col = drawFile == null ? null : rnd.nextInt(10);
+      final network = networks[rnd.nextInt(networks.length)];
       final created = _randCreated();
       final updated = _randUpdatedAfter(created);
+      final physical = _randCreated();
+      final confirm = _randCreated();
+      final normalC = '기본 비고 $id';
+      final oaC = 'OA 비고 $id';
+      String _mac() {
+        String two() => rnd.nextInt(256).toRadixString(16).padLeft(2, '0');
+        return List.generate(6, (_) => two()).join('-');
+      }
+      final mac = _mac();
 
       _items.add(Asset(
         id: id,
@@ -139,10 +158,75 @@ class AssetRepository {
         serialNumber: sn,
         modelName: model,
         vendor: vendor,
+        building: building,
+        floor: floor,
+        memberName: member,
+        network: network,
+        physicalCheckDate: physical,
+        confirmationDate: confirm,
+        normalComment: normalC,
+        oaComment: oaC,
+        macAddress: mac,
         locationDrawingId: drawId,
         locationRow: row,
         locationCol: col,
-        locationDrawingFile: drawId == null ? null : kDrawingImageFiles[drawId],
+        locationDrawingFile: drawFile,
+        createdAt: created,
+        updatedAt: updated,
+      ));
+    }
+
+    // 추가 10개 랜덤 생성
+    for (int i = 0; i < 10; i++) {
+      final id = _nextId();
+      final code = _genCode();
+      final cat1 = cats1[rnd.nextInt(cats1.length)];
+      final cat2 = cats2[rnd.nextInt(cats2.length)];
+      final name = '$cat1-$id';
+      final vendor = vendors[rnd.nextInt(vendors.length)];
+      final model = models[rnd.nextInt(models.length)];
+      final sn = _serial();
+      final building = buildings[rnd.nextInt(buildings.length)];
+      final floor = floors[rnd.nextInt(floors.length)];
+      final member = members[rnd.nextInt(members.length)];
+      final drawFile = bgFiles[rnd.nextInt(bgFiles.length)];
+      final drawId = drawFile == null ? null : 'D${1 + rnd.nextInt(8)}';
+      final row = drawFile == null ? null : rnd.nextInt(10);
+      final col = drawFile == null ? null : rnd.nextInt(10);
+      final network = networks[rnd.nextInt(networks.length)];
+      final created = _randCreated();
+      final updated = _randUpdatedAfter(created);
+      final physical = _randCreated();
+      final confirm = _randCreated();
+      final normalC = '기본 비고 $id';
+      final oaC = 'OA 비고 $id';
+      String _mac() {
+        String two() => rnd.nextInt(256).toRadixString(16).padLeft(2, '0');
+        return List.generate(6, (_) => two()).join('-');
+      }
+      final mac = _mac();
+
+      _items.add(Asset(
+        id: id,
+        code: code,
+        name: name,
+        category: cat2,
+        serialNumber: sn,
+        modelName: model,
+        vendor: vendor,
+        building: building,
+        floor: floor,
+        memberName: member,
+        network: network,
+        physicalCheckDate: physical,
+        confirmationDate: confirm,
+        normalComment: normalC,
+        oaComment: oaC,
+        macAddress: mac,
+        locationDrawingId: drawId,
+        locationRow: row,
+        locationCol: col,
+        locationDrawingFile: drawFile,
         createdAt: created,
         updatedAt: updated,
       ));

--- a/lib/view/drawing/drawing_screen.dart
+++ b/lib/view/drawing/drawing_screen.dart
@@ -40,11 +40,15 @@ class DrawingScreen extends StatelessWidget {
                     separatorBuilder: (_, __) => const Divider(height: 1),
                     itemBuilder: (_, i) {
                       final d = items[i];
-                      final hasBg = d.imageBytes != null && d.imageBytes!.isNotEmpty;
+                      // 이미지 바이트가 로드되지 않았더라도 파일명이 지정되어 있으면 배경이 있는 것으로 간주
+                      final hasBg = d.imageName != null || kDrawingImageFiles[d.id] != null;
                       return ListTile(
                         leading: CircleAvatar(
                           backgroundColor: hasBg ? Colors.green : Colors.grey.shade300,
-                          child: Icon(hasBg ? Icons.image : Icons.image_not_supported, color: hasBg ? Colors.white : Colors.black38),
+                          child: Icon(
+                            hasBg ? Icons.image : Icons.image_not_supported,
+                            color: hasBg ? Colors.white : Colors.black38,
+                          ),
                         ),
                         title: Text('${d.building} · ${d.floor} · ${d.title}'),
                         subtitle: Text('격자: ${d.gridRows} x ${d.gridCols}'),

--- a/lib/view/screen/asset_detail_screen.dart
+++ b/lib/view/screen/asset_detail_screen.dart
@@ -5,6 +5,7 @@ import '../../provider/asset_provider.dart';
 import '../../provider/drawing_provider.dart';
 import 'package:go_router/go_router.dart';
 import '../../util/drawing_image_loader.dart';
+import '../../model/asset.dart';
 
 class AssetDetailScreen extends StatelessWidget {
   const AssetDetailScreen({super.key, required this.id});
@@ -20,10 +21,22 @@ class AssetDetailScreen extends StatelessWidget {
       return const Center(child: Text('자산을 찾을 수 없습니다.'));
     }
 
-    final hasLoc = asset.locationDrawingId != null;
-    final locStr = hasLoc
-        ? '${asset.locationDrawingId}  (${asset.locationRow}, ${asset.locationCol})'
-        : '미지정';
+    final hasLoc = asset.locationRow != null && asset.locationCol != null;
+    String locStr;
+    if (hasLoc) {
+      String building = asset.building ?? '';
+      String floor = asset.floor ?? '';
+      if (asset.locationDrawingFile != null) {
+        final parts = asset.locationDrawingFile!.split('_');
+        if (parts.length >= 2) {
+          building = parts[0];
+          floor = parts[1];
+        }
+      }
+      locStr = '$building, $floor (${asset.locationRow}, ${asset.locationCol})';
+    } else {
+      locStr = '미지정';
+    }
 
     return Padding(
       padding: const EdgeInsets.all(16),
@@ -34,7 +47,19 @@ class AssetDetailScreen extends StatelessWidget {
           const SizedBox(height: 8),
           _kv('코드', asset.code),
           _kv('분류', asset.category),
+          _kv('모델명', asset.modelName),
+          _kv('제조사', asset.vendor),
+          _kv('네트워크', asset.network ?? '-'),
+          _kv('시리얼', asset.serialNumber),
+          _kv('건물', asset.building ?? '-'),
+          _kv('층', asset.floor ?? '-'),
+          _kv('담당자', asset.memberName ?? '-'),
           _kv('위치', locStr),
+          _kv('실물점검일', asset.physicalCheckDate?.toIso8601String() ?? '-'),
+          _kv('검수일자', asset.confirmationDate?.toIso8601String() ?? '-'),
+          _kv('일반비고', asset.normalComment ?? '-'),
+          _kv('OA비고', asset.oaComment ?? '-'),
+          _kv('MAC', asset.macAddress ?? '-'),
           const SizedBox(height: 16),
           Wrap(
             spacing: 8,
@@ -78,6 +103,11 @@ class AssetDetailScreen extends StatelessWidget {
                   icon: const Icon(Icons.remove),
                   label: const Text('위치 해제'),
                 ),
+              OutlinedButton.icon(
+                onPressed: () => _openAssetEditor(context, asset),
+                icon: const Icon(Icons.edit),
+                label: const Text('정보 수정'),
+              ),
             ],
           ),
           const SizedBox(height: 16),
@@ -105,6 +135,13 @@ class AssetDetailScreen extends StatelessWidget {
     await showDialog(
       context: context,
       builder: (_) => _LocationDialog(assetId: assetId),
+    );
+  }
+
+  Future<void> _openAssetEditor(BuildContext context, Asset asset) async {
+    await showDialog(
+      context: context,
+      builder: (_) => _AssetEditDialog(asset: asset),
     );
   }
 }
@@ -202,6 +239,132 @@ class _LocationDialogState extends State<_LocationDialog> {
               drawingProvider: context.read<DrawingProvider>(),
             );
             if (context.mounted) Navigator.pop(context);
+          },
+          child: const Text('저장'),
+        ),
+      ],
+    );
+  }
+}
+
+class _AssetEditDialog extends StatefulWidget {
+  const _AssetEditDialog({required this.asset});
+  final Asset asset;
+
+  @override
+  State<_AssetEditDialog> createState() => _AssetEditDialogState();
+}
+
+class _AssetEditDialogState extends State<_AssetEditDialog> {
+  late final TextEditingController _code;
+  late final TextEditingController _name;
+  late final TextEditingController _category;
+  late final TextEditingController _serial;
+  late final TextEditingController _model;
+  late final TextEditingController _vendor;
+  late final TextEditingController _network;
+  late final TextEditingController _building;
+  late final TextEditingController _floor;
+  late final TextEditingController _member;
+  late final TextEditingController _physical;
+  late final TextEditingController _confirm;
+  late final TextEditingController _normal;
+  late final TextEditingController _oa;
+  late final TextEditingController _mac;
+
+  @override
+  void initState() {
+    super.initState();
+    final a = widget.asset;
+    _code = TextEditingController(text: a.code);
+    _name = TextEditingController(text: a.name);
+    _category = TextEditingController(text: a.category);
+    _serial = TextEditingController(text: a.serialNumber);
+    _model = TextEditingController(text: a.modelName);
+    _vendor = TextEditingController(text: a.vendor);
+    _network = TextEditingController(text: a.network ?? '');
+    _building = TextEditingController(text: a.building ?? '');
+    _floor = TextEditingController(text: a.floor ?? '');
+    _member = TextEditingController(text: a.memberName ?? '');
+    _physical = TextEditingController(text: a.physicalCheckDate?.toIso8601String() ?? '');
+    _confirm = TextEditingController(text: a.confirmationDate?.toIso8601String() ?? '');
+    _normal = TextEditingController(text: a.normalComment ?? '');
+    _oa = TextEditingController(text: a.oaComment ?? '');
+    _mac = TextEditingController(text: a.macAddress ?? '');
+  }
+
+  @override
+  void dispose() {
+    _code.dispose();
+    _name.dispose();
+    _category.dispose();
+    _serial.dispose();
+    _model.dispose();
+    _vendor.dispose();
+    _network.dispose();
+    _building.dispose();
+    _floor.dispose();
+    _member.dispose();
+    _physical.dispose();
+    _confirm.dispose();
+    _normal.dispose();
+    _oa.dispose();
+    _mac.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('자산 정보 수정'),
+      content: SizedBox(
+        width: 400,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(controller: _code, decoration: const InputDecoration(labelText: '코드')),
+              TextField(controller: _name, decoration: const InputDecoration(labelText: '자산명')),
+              TextField(controller: _category, decoration: const InputDecoration(labelText: '분류')),
+              TextField(controller: _serial, decoration: const InputDecoration(labelText: '시리얼')),
+              TextField(controller: _model, decoration: const InputDecoration(labelText: '모델명')),
+              TextField(controller: _vendor, decoration: const InputDecoration(labelText: '제조사')),
+              TextField(controller: _network, decoration: const InputDecoration(labelText: '네트워크')),
+              TextField(controller: _building, decoration: const InputDecoration(labelText: '건물')),
+              TextField(controller: _floor, decoration: const InputDecoration(labelText: '층')),
+              TextField(controller: _member, decoration: const InputDecoration(labelText: '담당자')),
+              TextField(controller: _physical, decoration: const InputDecoration(labelText: '실물점검일(YYYY-MM-DD)')),
+              TextField(controller: _confirm, decoration: const InputDecoration(labelText: '검수일자(YYYY-MM-DD)')),
+              TextField(controller: _normal, decoration: const InputDecoration(labelText: '일반비고')),
+              TextField(controller: _oa, decoration: const InputDecoration(labelText: 'OA비고')),
+              TextField(controller: _mac, decoration: const InputDecoration(labelText: 'MAC 주소')),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(onPressed: () => Navigator.pop(context), child: const Text('취소')),
+        FilledButton(
+          onPressed: () {
+            final updated = widget.asset.copyWith(
+              code: _code.text,
+              name: _name.text,
+              category: _category.text,
+              serialNumber: _serial.text,
+              modelName: _model.text,
+              vendor: _vendor.text,
+              network: _network.text.isEmpty ? null : _network.text,
+              building: _building.text.isEmpty ? null : _building.text,
+              floor: _floor.text.isEmpty ? null : _floor.text,
+              memberName: _member.text.isEmpty ? null : _member.text,
+              physicalCheckDate: _physical.text.isEmpty ? null : DateTime.tryParse(_physical.text),
+              confirmationDate: _confirm.text.isEmpty ? null : DateTime.tryParse(_confirm.text),
+              normalComment: _normal.text.isEmpty ? null : _normal.text,
+              oaComment: _oa.text.isEmpty ? null : _oa.text,
+              macAddress: _mac.text.isEmpty ? null : _mac.text,
+            );
+            context.read<AssetProvider>().update(updated);
+            Navigator.pop(context);
           },
           child: const Text('저장'),
         ),

--- a/lib/view/screen/asset_list_screen.dart
+++ b/lib/view/screen/asset_list_screen.dart
@@ -77,8 +77,10 @@ class _AssetListScreenState extends State<AssetListScreen> {
                     separatorBuilder: (_, __) => const Divider(height: 1),
                     itemBuilder: (_, i) {
                       final a = filtered[i];
-                      final hasLoc = a.locationDrawingId != null;
-                      final locText = hasLoc ? '위치: ${a.locationDrawingId} (${a.locationRow}, ${a.locationCol})' : '위치: 미지정';
+                      final hasLoc = a.locationRow != null && a.locationCol != null;
+                      final locText = hasLoc
+                          ? '위치: ${a.building ?? ''}, ${a.floor ?? ''} (${a.locationRow}, ${a.locationCol})'
+                          : '위치: 미지정';
                       return ListTile(
                         leading: const Icon(Icons.inventory_2),
                         title: Text(a.name),


### PR DESCRIPTION
## Summary
- expand asset model with network, audit dates, comments, and MAC address
- seed assets using building/floor definitions and new user name lists
- show and edit complete asset details including parsed building/floor info
- rename buildingPic model file to match requested naming

## Testing
- `dart format lib/model/buildingPic.dart lib/repository/asset_repository.dart lib/provider/asset_provider.dart lib/view/drawing/drawing_screen.dart lib/view/screen/asset_detail_screen.dart lib/view/screen/asset_list_screen.dart lib/model/user.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c7fb4865148322811a0cfc150e10de