### PR TITLE
Add building and user models and expand asset details

### DIFF
--- a/lib/model/asset.dart
+++ b/lib/model/asset.dart
@@ -24,6 +24,24 @@ class Asset {
   /// 공급사/제조사
   String vendor;
 
+  /// 네트워크 (업무망, 개발망 등)
+  String? network;
+
+  /// 실사일
+  DateTime? physicalCheckDate;
+
+  /// 확정일
+  DateTime? confirmationDate;
+
+  /// 일반 비고
+  String? normalComment;
+
+  /// OA 비고
+  String? oaComment;
+
+  /// MAC 주소
+  String? macAddress;
+
   /// 건물명(선택)
   String? building;
 
@@ -51,6 +69,12 @@ class Asset {
     required this.serialNumber,
     required this.modelName,
     required this.vendor,
+    this.network,
+    this.physicalCheckDate,
+    this.confirmationDate,
+    this.normalComment,
+    this.oaComment,
+    this.macAddress,
     this.building,
     this.floor,
     this.memberName,
@@ -69,6 +93,12 @@ class Asset {
     String? serialNumber,
     String? modelName,
     String? vendor,
+    String? network,
+    DateTime? physicalCheckDate,
+    DateTime? confirmationDate,
+    String? normalComment,
+    String? oaComment,
+    String? macAddress,
     String? building,
     String? floor,
     String? memberName,
@@ -87,6 +117,12 @@ class Asset {
       serialNumber: serialNumber ?? this.serialNumber,
       modelName: modelName ?? this.modelName,
       vendor: vendor ?? this.vendor,
+      network: network ?? this.network,
+      physicalCheckDate: physicalCheckDate ?? this.physicalCheckDate,
+      confirmationDate: confirmationDate ?? this.confirmationDate,
+      normalComment: normalComment ?? this.normalComment,
+      oaComment: oaComment ?? this.oaComment,
+      macAddress: macAddress ?? this.macAddress,
       building: building ?? this.building,
       floor: floor ?? this.floor,
       memberName: memberName ?? this.memberName,

--- a/lib/model/buildingPic.dart
+++ b/lib/model/buildingPic.dart
@@ -1,0 +1,40 @@
+// lib/model/buildingPic.dart
+
+class BuildingPic {
+  final String? buildingName;
+  final String floor;
+  final String? buildingBgFile;
+
+  const BuildingPic({
+    required this.buildingName,
+    required this.floor,
+    this.buildingBgFile,
+  });
+}
+
+const List<String?> kBuildingNames = [
+  '콘코디언',
+  '한경경제신문사',
+  '본사',
+  '센터',
+  'CRM',
+  null,
+];
+
+final List<String> kFloors = [
+  'B7',
+  'B6',
+  'B5',
+  'B4',
+  'B3',
+  'B2',
+  'B1',
+  'L',
+  for (var i = 1; i <= 22; i++) 'F$i',
+];
+
+const List<String?> kBuildingBgFiles = [
+  'hankyung_16F_A.png',
+  'conco_11F_A.jpg',
+  null,
+];

--- a/lib/model/user.dart
+++ b/lib/model/user.dart
@@ -1,0 +1,97 @@
+// lib/model/user.dart
+
+import 'dart:math';
+
+class User {
+  final String no; // 오름차순 순번
+  final String employeeId; // B/P/A + 6 digits
+  final String employeeName; // 연예인 이름
+  final String? organizationNameHQ;
+  final String? organizationNameDept;
+  final String? organizationNameTeam;
+  final String? organizationNamePart;
+  final String? organizationNameEtc;
+  final String? workBuilding; // building name
+  final String? workFloor; // floor
+
+  const User({
+    required this.no,
+    required this.employeeId,
+    required this.employeeName,
+    this.organizationNameHQ,
+    this.organizationNameDept,
+    this.organizationNameTeam,
+    this.organizationNamePart,
+    this.organizationNameEtc,
+    this.workBuilding,
+    this.workFloor,
+  });
+}
+
+// 샘플 연예인 이름 (asset.memberName과 연결)
+const List<String> kEmployeeNames = ['아이유', '차은우', '손예진', '박보검'];
+
+// 조직명 목록
+const List<String?> kOrganizationNameHQ = [
+  '개발본부',
+  '영업본부',
+  '기획본부',
+  '운영본부',
+  '마케팅본부',
+  null,
+];
+
+const List<String?> kOrganizationNameDept = [
+  '개발1실',
+  '개발2실',
+  '영업1실',
+  '영업2실',
+  '기획1실',
+  '기획2실',
+  '운영1실',
+  '운영2실',
+  '마케팅1실',
+  '마케팅2실',
+  null,
+];
+
+const List<String?> kOrganizationNameTeam = [
+  '프론트개발팀',
+  '백엔드개발팀',
+  '해외영업팀',
+  '국내영업팀',
+  '구매기획팀',
+  '운영기획팀',
+  'IT운영1팀',
+  'IT운영2팀',
+  '직작인마케팅팀',
+  '학생마케팅팀',
+  '음악인마케팅팀',
+  '은퇴자마케팅팀',
+  null,
+];
+
+const List<String?> kOrganizationNamePart = [
+  '콜업무',
+  '추심업무',
+  '제작업무',
+  '영업업무',
+  '고객응대업무',
+  null,
+];
+
+const List<String?> kOrganizationNameEtc = [
+  '대표이사',
+  '감사',
+  '소비자보호',
+  '고문',
+  null,
+];
+
+// 임직원 ID 생성기
+String generateEmployeeId(Random rnd) {
+  const prefixes = ['B', 'P', 'A'];
+  final prefix = prefixes[rnd.nextInt(prefixes.length)];
+  final numPart = rnd.nextInt(1000000).toString().padLeft(6, '0');
+  return '$prefix$numPart';
+}

--- a/lib/provider/asset_provider.dart
+++ b/lib/provider/asset_provider.dart
@@ -20,6 +20,13 @@ class AssetProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  Asset? updateAsset(Asset asset) {
+    final updated = repo.update(asset);
+    items = repo.list();
+    notifyListeners();
+    return updated;
+  }
+
   // 자산 위치 변경 + 도면 셀에 동기화
   Future<Asset?> setLocationAndSync({
     required String assetId,

--- a/lib/repository/asset_repository.dart
+++ b/lib/repository/asset_repository.dart
@@ -1,6 +1,8 @@
 // lib/repository/asset_repository.dart
 import 'dart:math';
 import '../model/asset.dart';
+import '../model/buildingPic.dart';
+import '../model/user.dart';
 
 class AssetRepository {
   final List<Asset> _items = [];
@@ -55,16 +57,14 @@ class AssetRepository {
   void _seed20() {
     final rnd = Random();
     final vendors = ['Samsung', 'LG', 'Siemens', 'FANUC', 'Omron', 'Keyence', 'Bosch', 'Panasonic'];
-    final models  = ['X100', 'M450', 'S2-Pro', 'VX-9', 'HF-220', 'Prime-7', 'Neo-3', 'Edge-11'];
-    final cats2   = ['생산설비', 'IT장비', '품질장비', '공용비품', '안전설비'];
-    final cats1   = ['모니터', '프린터', '데스크탑', '노트북', '태블릿', '스캐너', 'Test폰', '기타'];
-    final buildings = ['콘코디언', '한경경제신문사', '본사', '센터', 'CRM', null];
-    final floors = [
-      'B7', 'B6', 'B5', 'B4', 'B3', 'B2', 'B1', 'L',
-      for (var i = 1; i <= 22; i++) 'F$i',
-    ];
-    const List<String?> bgFiles = ['hankyung_16F_A.png', 'conco_11F_A.jpg', null];
-    final members = ['차두리', '강남길', '김유정', '김소연', '이나영', null];
+    final models = ['X100', 'M450', 'S2-Pro', 'VX-9', 'HF-220', 'Prime-7', 'Neo-3', 'Edge-11'];
+    final cats2 = ['생산설비', 'IT장비', '품질장비', '공용비품', '안전설비'];
+    final cats1 = ['모니터', '프린터', '데스크탑', '노트북', '태블릿', '스캐너', 'Test폰', '기타'];
+    final buildings = kBuildingNames;
+    final floors = kFloors;
+    const List<String?> bgFiles = kBuildingBgFiles;
+    final members = [...kEmployeeNames, null];
+    final networks = ['업무망', '개발망', '시스템망', '인터넷망', null];
 
     // 최근 365일 내 랜덤 생성일
     DateTime _randCreated() {
@@ -86,7 +86,7 @@ class AssetRepository {
     String _genCode() {
       while (true) {
         final letter = String.fromCharCode('A'.codeUnitAt(0) + rnd.nextInt(26));
-        final num5   = rnd.nextInt(100000).toString().padLeft(5, '0');
+        final num5 = rnd.nextInt(100000).toString().padLeft(5, '0');
         final code = '$letter$num5';
         if (!usedCodes.contains(code)) {
           usedCodes.add(code);
@@ -100,6 +100,12 @@ class AssetRepository {
       const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
       String pick(int n) => List.generate(n, (_) => chars[rnd.nextInt(chars.length)]).join();
       return '${pick(4)}-${pick(4)}-${pick(4)}';
+    }
+
+    // MAC 주소 생성
+    String _mac() {
+      String hex() => rnd.nextInt(256).toRadixString(16).padLeft(2, '0');
+      return '${hex()}-${hex()}-${hex()}-${hex()}-${hex()}-${hex()}';
     }
 
     // 오름차순 id 생성 ("1","2","3"...)
@@ -139,6 +145,12 @@ class AssetRepository {
       final col = drawFile == null ? null : rnd.nextInt(10);
       final created = _randCreated();
       final updated = _randUpdatedAfter(created);
+      final network = networks[rnd.nextInt(networks.length)];
+      final pCheck = _randCreated();
+      final confirm = _randUpdatedAfter(pCheck);
+      final nComment = '일반 비고 $id';
+      final oComment = 'OA 비고 $id';
+      final mac = _mac();
 
       _items.add(Asset(
         id: id,
@@ -148,6 +160,12 @@ class AssetRepository {
         serialNumber: sn,
         modelName: model,
         vendor: vendor,
+        network: network,
+        physicalCheckDate: pCheck,
+        confirmationDate: confirm,
+        normalComment: nComment,
+        oaComment: oComment,
+        macAddress: mac,
         building: building,
         floor: floor,
         memberName: member,
@@ -179,6 +197,12 @@ class AssetRepository {
       final col = drawFile == null ? null : rnd.nextInt(10);
       final created = _randCreated();
       final updated = _randUpdatedAfter(created);
+      final network = networks[rnd.nextInt(networks.length)];
+      final pCheck = _randCreated();
+      final confirm = _randUpdatedAfter(pCheck);
+      final nComment = '일반 비고 $id';
+      final oComment = 'OA 비고 $id';
+      final mac = _mac();
 
       _items.add(Asset(
         id: id,
@@ -188,6 +212,12 @@ class AssetRepository {
         serialNumber: sn,
         modelName: model,
         vendor: vendor,
+        network: network,
+        physicalCheckDate: pCheck,
+        confirmationDate: confirm,
+        normalComment: nComment,
+        oaComment: oComment,
+        macAddress: mac,
         building: building,
         floor: floor,
         memberName: member,

--- a/lib/view/screen/asset_detail_screen.dart
+++ b/lib/view/screen/asset_detail_screen.dart
@@ -1,10 +1,11 @@
 // lib/view/screen/asset_detail_screen.dart
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:go_router/go_router.dart';
 import '../../provider/asset_provider.dart';
 import '../../provider/drawing_provider.dart';
-import 'package:go_router/go_router.dart';
 import '../../util/drawing_image_loader.dart';
+import '../../model/asset.dart';
 
 class AssetDetailScreen extends StatelessWidget {
   const AssetDetailScreen({super.key, required this.id});
@@ -32,23 +33,40 @@ class AssetDetailScreen extends StatelessWidget {
 
     return Padding(
       padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      child: ListView(
         children: [
           Text(asset.name, style: Theme.of(context).textTheme.headlineSmall),
           const SizedBox(height: 8),
           _kv('코드', asset.code),
           _kv('분류', asset.category),
+          _kv('시리얼', asset.serialNumber),
+          _kv('모델명', asset.modelName),
+          _kv('제조사', asset.vendor),
+          _kv('건물', asset.building),
+          _kv('층', asset.floor),
+          _kv('담당자', asset.memberName),
+          _kv('망', asset.network),
+          _kv('실사일', _fmtDate(asset.physicalCheckDate)),
+          _kv('확정일', _fmtDate(asset.confirmationDate)),
+          _kv('일반비고', asset.normalComment),
+          _kv('OA비고', asset.oaComment),
+          _kv('MAC', asset.macAddress),
           _kv('위치', locStr),
+          _kv('생성일', _fmtDate(asset.createdAt)),
+          _kv('수정일', _fmtDate(asset.updatedAt)),
           const SizedBox(height: 16),
           Wrap(
             spacing: 8,
             runSpacing: 8,
             children: [
+              FilledButton.icon(
+                onPressed: () => _openInfoEditor(context, asset),
+                icon: const Icon(Icons.edit),
+                label: const Text('정보 수정'),
+              ),
               if (hasLoc)
                 FilledButton.icon(
                   onPressed: () async {
-                    // 도면 배경이 없으면 자산에 지정된 파일을 로드 후 이동
                     final d = dp.getById(asset.locationDrawingId!);
                     if (d != null) {
                       await loadDrawingImageIfNeeded(
@@ -94,22 +112,159 @@ class AssetDetailScreen extends StatelessWidget {
     );
   }
 
-  Widget _kv(String k, String v) {
+  Widget _kv(String k, String? v) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 2),
       child: Row(
         children: [
-          SizedBox(width: 80, child: Text(k, style: const TextStyle(color: Colors.black54))),
-          Expanded(child: Text(v)),
+          SizedBox(width: 100, child: Text(k, style: const TextStyle(color: Colors.black54))),
+          Expanded(child: Text(v ?? '')),
         ],
       ),
     );
   }
 
+  String _fmtDate(DateTime? d) => d == null ? '' : d.toIso8601String().split('T').first;
+
   Future<void> _openLocationEditor(BuildContext context, String assetId) async {
     await showDialog(
       context: context,
       builder: (_) => _LocationDialog(assetId: assetId),
+    );
+  }
+
+  Future<void> _openInfoEditor(BuildContext context, Asset asset) async {
+    await showDialog(
+      context: context,
+      builder: (_) => _AssetInfoDialog(asset: asset),
+    );
+  }
+}
+
+class _AssetInfoDialog extends StatefulWidget {
+  const _AssetInfoDialog({required this.asset});
+  final Asset asset;
+
+  @override
+  State<_AssetInfoDialog> createState() => _AssetInfoDialogState();
+}
+
+class _AssetInfoDialogState extends State<_AssetInfoDialog> {
+  late final TextEditingController code;
+  late final TextEditingController name;
+  late final TextEditingController category;
+  late final TextEditingController serial;
+  late final TextEditingController model;
+  late final TextEditingController vendor;
+  late final TextEditingController building;
+  late final TextEditingController floor;
+  late final TextEditingController memberName;
+  late final TextEditingController network;
+  late final TextEditingController pCheck;
+  late final TextEditingController confirm;
+  late final TextEditingController normal;
+  late final TextEditingController oa;
+  late final TextEditingController mac;
+
+  @override
+  void initState() {
+    super.initState();
+    final a = widget.asset;
+    code = TextEditingController(text: a.code);
+    name = TextEditingController(text: a.name);
+    category = TextEditingController(text: a.category);
+    serial = TextEditingController(text: a.serialNumber);
+    model = TextEditingController(text: a.modelName);
+    vendor = TextEditingController(text: a.vendor);
+    building = TextEditingController(text: a.building ?? '');
+    floor = TextEditingController(text: a.floor ?? '');
+    memberName = TextEditingController(text: a.memberName ?? '');
+    network = TextEditingController(text: a.network ?? '');
+    pCheck = TextEditingController(text: _fmtDate(a.physicalCheckDate));
+    confirm = TextEditingController(text: _fmtDate(a.confirmationDate));
+    normal = TextEditingController(text: a.normalComment ?? '');
+    oa = TextEditingController(text: a.oaComment ?? '');
+    mac = TextEditingController(text: a.macAddress ?? '');
+  }
+
+  @override
+  void dispose() {
+    code.dispose();
+    name.dispose();
+    category.dispose();
+    serial.dispose();
+    model.dispose();
+    vendor.dispose();
+    building.dispose();
+    floor.dispose();
+    memberName.dispose();
+    network.dispose();
+    pCheck.dispose();
+    confirm.dispose();
+    normal.dispose();
+    oa.dispose();
+    mac.dispose();
+    super.dispose();
+  }
+
+  DateTime? _parseDate(String s) => s.isEmpty ? null : DateTime.tryParse(s);
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('자산 정보 수정'),
+      content: SizedBox(
+        width: 420,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(controller: name, decoration: const InputDecoration(labelText: '자산명')),
+              TextField(controller: code, decoration: const InputDecoration(labelText: '코드')),
+              TextField(controller: category, decoration: const InputDecoration(labelText: '분류')),
+              TextField(controller: serial, decoration: const InputDecoration(labelText: '시리얼번호')),
+              TextField(controller: model, decoration: const InputDecoration(labelText: '모델명')),
+              TextField(controller: vendor, decoration: const InputDecoration(labelText: '제조사')),
+              TextField(controller: building, decoration: const InputDecoration(labelText: '건물')),
+              TextField(controller: floor, decoration: const InputDecoration(labelText: '층')),
+              TextField(controller: memberName, decoration: const InputDecoration(labelText: '담당자')),
+              TextField(controller: network, decoration: const InputDecoration(labelText: '망')),
+              TextField(controller: pCheck, decoration: const InputDecoration(labelText: '실사일(YYYY-MM-DD)')),
+              TextField(controller: confirm, decoration: const InputDecoration(labelText: '확정일(YYYY-MM-DD)')),
+              TextField(controller: normal, decoration: const InputDecoration(labelText: '일반비고')),
+              TextField(controller: oa, decoration: const InputDecoration(labelText: 'OA비고')),
+              TextField(controller: mac, decoration: const InputDecoration(labelText: 'MAC 주소')),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(onPressed: () => Navigator.pop(context), child: const Text('취소')),
+        FilledButton(
+          onPressed: () {
+            final updated = widget.asset.copyWith(
+              name: name.text,
+              code: code.text,
+              category: category.text,
+              serialNumber: serial.text,
+              modelName: model.text,
+              vendor: vendor.text,
+              building: building.text.isEmpty ? null : building.text,
+              floor: floor.text.isEmpty ? null : floor.text,
+              memberName: memberName.text.isEmpty ? null : memberName.text,
+              network: network.text.isEmpty ? null : network.text,
+              physicalCheckDate: _parseDate(pCheck.text),
+              confirmationDate: _parseDate(confirm.text),
+              normalComment: normal.text.isEmpty ? null : normal.text,
+              oaComment: oa.text.isEmpty ? null : oa.text,
+              macAddress: mac.text.isEmpty ? null : mac.text,
+            );
+            context.read<AssetProvider>().updateAsset(updated);
+            Navigator.pop(context);
+          },
+          child: const Text('저장'),
+        ),
+      ],
     );
   }
 }
@@ -153,9 +308,9 @@ class _LocationDialogState extends State<_LocationDialog> {
               decoration: const InputDecoration(labelText: '도면 선택'),
               items: drawings
                   .map((d) => DropdownMenuItem(
-                value: d.id,
-                child: Text('${d.building} · ${d.floor} · ${d.title}'),
-              ))
+                        value: d.id,
+                        child: Text('${d.building} · ${d.floor} · ${d.title}'),
+                      ))
                   .toList(),
               onChanged: (v) => setState(() => _drawingId = v),
             ),


### PR DESCRIPTION
## Summary
- Add buildingPic model with common building/floor data
- Introduce user model and sample organization/name lists
- Extend asset model with network, comments, MAC, and dates
- Seed new asset fields and expose update method
- Allow full asset info viewing and editing in detail screen

## Testing
- `dart format lib/model/buildingPic.dart lib/model/user.dart lib/model/asset.dart lib/repository/asset_repository.dart lib/provider/asset_provider.dart lib/view/screen/asset_detail_screen.dart` *(command failed: dart: command not found)*
- `flutter --version` *(command failed: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c825be27b88322bdc460cce542e2bf