### PR TITLE
Implement 2x2 draggable markers on drawing map

### DIFF
--- a/lib/model/drawing.dart
+++ b/lib/model/drawing.dart
@@ -3,6 +3,9 @@ import 'dart:typed_data';
 
 /// 도면 모델 (건물 · 층별)
 class Drawing {
+  /// 마커가 차지하는 격자 크기 (행, 열)
+  static const int markerBlockSpan = 2;
+
   final String id;           // 고유 ID
   final String building;           // 건물명
   final String floor;              // 층 (예: B1, 1F, 2F)

--- a/lib/util/grid_marker.dart
+++ b/lib/util/grid_marker.dart
@@ -1,0 +1,191 @@
+// lib/util/grid_marker.dart
+
+import '../model/drawing.dart';
+
+/// 셀 키 문자열을 (row, col) 튜플로 변환합니다. 잘못된 포맷이면 null.
+(int, int)? parseCellKey(String key) {
+  try {
+    final rIdx = key.indexOf('r');
+    final cIdx = key.indexOf('c');
+    if (rIdx != 0 || cIdx < 0) return null;
+    final row = int.parse(key.substring(1, cIdx));
+    final col = int.parse(key.substring(cIdx + 1));
+    return (row, col);
+  } catch (_) {
+    return null;
+  }
+}
+
+/// 주어진 위치를 마커 크기에 맞춰 정규화한 (row, col)을 반환합니다.
+/// - span 보다 작은 격자에서는 항상 (0,0)을 반환합니다.
+(int, int) normalizeBlockOrigin({
+  required int row,
+  required int col,
+  required int rows,
+  required int cols,
+  int span = Drawing.markerBlockSpan,
+}) {
+  int _normalizeIndex(int value, int maxCount) {
+    if (maxCount <= span) {
+      return 0;
+    }
+    final maxStart = maxCount - span;
+    int clamped = value;
+    if (clamped < 0) clamped = 0;
+    if (clamped > maxStart) clamped = maxStart;
+    return (clamped ~/ span) * span;
+  }
+
+  return (_normalizeIndex(row, rows), _normalizeIndex(col, cols));
+}
+
+/// (row, col) → `r{row}c{col}` 포맷의 셀 키로 변환합니다.
+String cellKeyFrom({required int row, required int col}) => 'r${row}c$col';
+
+/// 특정 위치에 마커를 배치할 수 있는지 검사합니다.
+/// [row], [col]은 반드시 `normalizeBlockOrigin`을 거친 값이어야 합니다.
+bool canPlaceMarker({
+  required Map<String, List<String>> cellAssets,
+  required int row,
+  required int col,
+  required int rows,
+  required int cols,
+  String? ignoreKey,
+  int span = Drawing.markerBlockSpan,
+}) {
+  final targetKey = cellKeyFrom(row: row, col: col);
+
+  String? ignoreNormalizedKey;
+  if (ignoreKey != null) {
+    final parsed = parseCellKey(ignoreKey);
+    if (parsed != null) {
+      final normalized = normalizeBlockOrigin(
+        row: parsed.$1,
+        col: parsed.$2,
+        rows: rows,
+        cols: cols,
+        span: span,
+      );
+      ignoreNormalizedKey = cellKeyFrom(row: normalized.$1, col: normalized.$2);
+    }
+  }
+
+  for (final entry in cellAssets.entries) {
+    if (entry.value.isEmpty) continue;
+    final parsed = parseCellKey(entry.key);
+    if (parsed == null) continue;
+    final normalized = normalizeBlockOrigin(
+      row: parsed.$1,
+      col: parsed.$2,
+      rows: rows,
+      cols: cols,
+      span: span,
+    );
+    final otherKey = cellKeyFrom(row: normalized.$1, col: normalized.$2);
+    if (otherKey == targetKey || (ignoreNormalizedKey != null && otherKey == ignoreNormalizedKey)) {
+      continue; // 동일 위치 또는 무시 대상
+    }
+
+    final otherRow = normalized.$1;
+    final otherCol = normalized.$2;
+    final intersects = row < otherRow + span &&
+        row + span > otherRow &&
+        col < otherCol + span &&
+        col + span > otherCol;
+    if (intersects) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// 정규화된 위치에 포함된 자산 ID를 모두 수집합니다.
+Set<String> collectAreaAssetIds({
+  required Map<String, List<String>> cellAssets,
+  required int row,
+  required int col,
+  required int rows,
+  required int cols,
+  int span = Drawing.markerBlockSpan,
+}) {
+  final normalized = normalizeBlockOrigin(
+    row: row,
+    col: col,
+    rows: rows,
+    cols: cols,
+    span: span,
+  );
+  final targetKey = cellKeyFrom(row: normalized.$1, col: normalized.$2);
+
+  final result = <String>{};
+  for (final entry in cellAssets.entries) {
+    if (entry.value.isEmpty) continue;
+    final parsed = parseCellKey(entry.key);
+    if (parsed == null) continue;
+    final normalizedEntry = normalizeBlockOrigin(
+      row: parsed.$1,
+      col: parsed.$2,
+      rows: rows,
+      cols: cols,
+      span: span,
+    );
+    final key = cellKeyFrom(row: normalizedEntry.$1, col: normalizedEntry.$2);
+    if (key == targetKey) {
+      result.addAll(entry.value);
+    }
+  }
+  return result;
+}
+
+/// 격자 전체를 순회하며 정규화된 영역별 자산 ID 목록을 생성합니다.
+Map<String, Set<String>> groupAssetsByArea({
+  required Map<String, List<String>> cellAssets,
+  required int rows,
+  required int cols,
+  int span = Drawing.markerBlockSpan,
+}) {
+  final grouped = <String, Set<String>>{};
+  cellAssets.forEach((key, ids) {
+    if (ids.isEmpty) return;
+    final parsed = parseCellKey(key);
+    if (parsed == null) return;
+    final normalized = normalizeBlockOrigin(
+      row: parsed.$1,
+      col: parsed.$2,
+      rows: rows,
+      cols: cols,
+      span: span,
+    );
+    final areaKey = cellKeyFrom(row: normalized.$1, col: normalized.$2);
+    final areaSet = grouped.putIfAbsent(areaKey, () => <String>{});
+    areaSet.addAll(ids);
+  });
+  return grouped;
+}
+
+/// 정규화된 영역과 실제 저장된 키를 매핑합니다.
+Map<String, List<String>> mapAreaToOriginalKeys({
+  required Map<String, List<String>> cellAssets,
+  required int rows,
+  required int cols,
+  int span = Drawing.markerBlockSpan,
+}) {
+  final grouped = <String, List<String>>{};
+  cellAssets.forEach((key, ids) {
+    if (ids.isEmpty) return;
+    final parsed = parseCellKey(key);
+    if (parsed == null) return;
+    final normalized = normalizeBlockOrigin(
+      row: parsed.$1,
+      col: parsed.$2,
+      rows: rows,
+      cols: cols,
+      span: span,
+    );
+    final areaKey = cellKeyFrom(row: normalized.$1, col: normalized.$2);
+    final list = grouped.putIfAbsent(areaKey, () => <String>[]);
+    list.add(key);
+  });
+  return grouped;
+}
+

--- a/lib/view/drawing/drawing_map_screen.dart
+++ b/lib/view/drawing/drawing_map_screen.dart
@@ -6,6 +6,7 @@ import '../../provider/drawing_provider.dart';
 import '../../provider/asset_provider.dart';
 import '../../model/drawing.dart';
 import '../../util/drawing_image_loader.dart';
+import '../../util/grid_marker.dart';
 
 // (선택) 격자/테두리 색만 모아두고 싶다면 상수로 둡니다.
 const _kGridColor = Color(0x18000000); // 검정(연한)
@@ -313,7 +314,6 @@ class _GridOverlayState extends State<_GridOverlay> {
   @override
   Widget build(BuildContext context) {
     final d = widget.d;
-    final ap = widget.assetProvider;
     final showMarkers = widget.showMarkers;
 
     return LayoutBuilder(
@@ -343,27 +343,58 @@ class _GridOverlayState extends State<_GridOverlay> {
         final cellH = canvasH / rows;
 
         // 5) 마커 좌표 (항상 r,c 기준 → 셀 중심)
+        final markerWidth = cellW * Drawing.markerBlockSpan;
+        final markerHeight = cellH * Drawing.markerBlockSpan;
+        final double currentScaleValue = _tc.value.getMaxScaleOnAxis();
+        final double markerScale = currentScaleValue > 0 ? currentScaleValue : 1.0;
+
         final markers = <Widget>[];
         if (showMarkers && d.cellAssets.isNotEmpty) {
-          d.cellAssets.forEach((key, ids) {
+          final grouped = groupAssetsByArea(
+            cellAssets: d.cellAssets,
+            rows: rows,
+            cols: cols,
+          );
+          grouped.forEach((key, ids) {
             if (ids.isEmpty) return;
-            final rc = _parseCellKey(key);
+            final rc = parseCellKey(key);
             if (rc == null) return;
-            final r = rc.$1;
-            final c = rc.$2;
-            if (r < 0 || c < 0 || r >= rows || c >= cols) return;
+            final areaRow = rc.$1;
+            final areaCol = rc.$2;
+            if (areaRow < 0 || areaCol < 0 || areaRow >= rows || areaCol >= cols) return;
 
-            final left = c * cellW + cellW / 2;
-            final top = r * cellH + cellH / 2;
+            final left = areaCol * cellW;
+            final top = areaRow * cellH;
+            final dragData = _MarkerDragData(
+              row: areaRow,
+              col: areaCol,
+              assetIds: List<String>.from(ids),
+            );
 
             markers.add(Positioned(
-              left: left - 14,
-              top: top - 14,
-              width: 15,
-              height: 15,
-              child: _AssetMarker(
-                count: ids.length,
-                onTap: () => _openCellDialog(context, d, r, c),
+              left: left,
+              top: top,
+              width: markerWidth,
+              height: markerHeight,
+              child: LongPressDraggable<_MarkerDragData>(
+                data: dragData,
+                feedback: SizedBox(
+                  width: markerWidth * markerScale,
+                  height: markerHeight * markerScale,
+                  child: IgnorePointer(
+                    ignoring: true,
+                    child: _AssetMarker(
+                      count: ids.length,
+                      onTap: () {},
+                      isDragging: true,
+                    ),
+                  ),
+                ),
+                childWhenDragging: const SizedBox.shrink(),
+                child: _AssetMarker(
+                  count: ids.length,
+                  onTap: () => _openCellDialog(context, d, areaRow, areaCol),
+                ),
               ),
             ));
           });
@@ -414,12 +445,37 @@ class _GridOverlayState extends State<_GridOverlay> {
 
                   // (3) 탭: 캔버스 좌표 → (r,c)
                   Positioned.fill(
-                    child: _CellTappableAreaProportional(
-                      rows: rows,
-                      cols: cols,
-                      canvasW: canvasW,
-                      canvasH: canvasH,
-                      onCellTap: (r, c) => _openCellDialog(context, d, r, c),
+                    child: Builder(
+                      builder: (dragContext) {
+                        return DragTarget<_MarkerDragData>(
+                          onWillAccept: (_) => true,
+                          onAcceptWithDetails: (details) async {
+                            final renderBox = dragContext.findRenderObject() as RenderBox?;
+                            if (renderBox == null) return;
+                            final local = renderBox.globalToLocal(details.offset);
+                            await _handleMarkerDrop(
+                              context: dragContext,
+                              data: details.data,
+                              localPosition: local,
+                              canvasW: canvasW,
+                              canvasH: canvasH,
+                              cellW: cellW,
+                              cellH: cellH,
+                              rows: rows,
+                              cols: cols,
+                            );
+                          },
+                          builder: (context, candidate, rejected) {
+                            return _CellTappableAreaProportional(
+                              rows: rows,
+                              cols: cols,
+                              canvasW: canvasW,
+                              canvasH: canvasH,
+                              onCellTap: (r, c) => _openCellDialog(context, d, r, c),
+                            );
+                          },
+                        );
+                      },
                     ),
                   ),
 
@@ -434,16 +490,88 @@ class _GridOverlayState extends State<_GridOverlay> {
     );
   }
 
-  (int, int)? _parseCellKey(String key) {
+  Future<void> _handleMarkerDrop({
+    required BuildContext context,
+    required _MarkerDragData data,
+    required Offset localPosition,
+    required double canvasW,
+    required double canvasH,
+    required double cellW,
+    required double cellH,
+    required int rows,
+    required int cols,
+  }) async {
+    if (data.assetIds.isEmpty || rows <= 0 || cols <= 0) {
+      return;
+    }
+
+    double dx = localPosition.dx;
+    double dy = localPosition.dy;
+    if (dx.isNaN || dy.isNaN) {
+      return;
+    }
+    if (canvasW > 0) {
+      dx = dx.clamp(0.0, canvasW - 0.0001);
+    }
+    if (canvasH > 0) {
+      dy = dy.clamp(0.0, canvasH - 0.0001);
+    }
+
+    int rawCol = (dx / cellW).floor();
+    int rawRow = (dy / cellH).floor();
+    rawRow = rawRow.clamp(0, rows - 1);
+    rawCol = rawCol.clamp(0, cols - 1);
+
+    final normalized = normalizeBlockOrigin(
+      row: rawRow,
+      col: rawCol,
+      rows: rows,
+      cols: cols,
+    );
+    final targetRow = normalized.$1;
+    final targetCol = normalized.$2;
+
+    if (targetRow == data.row && targetCol == data.col) {
+      return;
+    }
+
+    final drawingProvider = context.read<DrawingProvider>();
+    final drawing = drawingProvider.getById(widget.d.id);
+    if (drawing == null) {
+      return;
+    }
+
+    final canPlace = canPlaceMarker(
+      cellAssets: drawing.cellAssets,
+      row: targetRow,
+      col: targetCol,
+      rows: drawing.gridRows,
+      cols: drawing.gridCols,
+      ignoreKey: data.areaKey,
+    );
+    if (!canPlace) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(this.context).showSnackBar(
+        const SnackBar(content: Text('다른 2×2 영역과 겹칠 수 없습니다.')),
+      );
+      return;
+    }
+
     try {
-      final rIdx = key.indexOf('r');
-      final cIdx = key.indexOf('c');
-      if (rIdx != 0 || cIdx < 0) return null;
-      final r = int.parse(key.substring(1, cIdx));
-      final c = int.parse(key.substring(cIdx + 1));
-      return (r, c);
-    } catch (_) {
-      return null;
+      for (final assetId in data.assetIds) {
+        await widget.assetProvider.setLocationAndSync(
+          assetId: assetId,
+          drawingId: drawing.id,
+          row: targetRow,
+          col: targetCol,
+          drawingProvider: drawingProvider,
+        );
+      }
+    } on StateError catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(this.context).showSnackBar(
+        const SnackBar(content: Text('다른 2×2 영역과 겹칠 수 없습니다.')),
+      );
     }
   }
 
@@ -451,8 +579,21 @@ class _GridOverlayState extends State<_GridOverlay> {
     final dp = context.read<DrawingProvider>();
     final ap = context.read<AssetProvider>();
 
-    final key = 'r${row}c$col';
-    final currentIds = List<String>.from(d.cellAssets[key] ?? const []);
+    final normalized = normalizeBlockOrigin(
+      row: row,
+      col: col,
+      rows: d.gridRows,
+      cols: d.gridCols,
+    );
+    final areaRow = normalized.$1;
+    final areaCol = normalized.$2;
+    final currentIds = collectAreaAssetIds(
+      cellAssets: d.cellAssets,
+      row: areaRow,
+      col: areaCol,
+      rows: d.gridRows,
+      cols: d.gridCols,
+    ).toList();
     final currentAssets = currentIds.map((id) => ap.getById(id)).whereType<dynamic>().toList();
 
     showModalBottomSheet(
@@ -470,7 +611,7 @@ class _GridOverlayState extends State<_GridOverlay> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text('자리: ($row, $col)', style: Theme.of(sheetContext).textTheme.titleMedium),
+              Text('자리: ($areaRow, $areaCol)', style: Theme.of(sheetContext).textTheme.titleMedium),
               const SizedBox(height: 8),
               if (currentAssets.isEmpty)
                 const ListTile(
@@ -493,7 +634,6 @@ class _GridOverlayState extends State<_GridOverlay> {
                           tooltip: '제거',
                           icon: const Icon(Icons.remove_circle_outline),
                           onPressed: () async {
-                            await dp.removeAssetFromCell(id: d.id, row: row, col: col, assetId: a.id);
                             await sheetContext.read<AssetProvider>().setLocationAndSync(
                                   assetId: a.id,
                                   drawingId: null,
@@ -502,7 +642,7 @@ class _GridOverlayState extends State<_GridOverlay> {
                                   drawingProvider: dp,
                                 );
                             if (sheetContext.mounted) Navigator.of(sheetContext).pop();
-                            _openCellDialog(context, dp.getById(d.id)!, row, col);
+                            _openCellDialog(context, dp.getById(d.id)!, areaRow, areaCol);
                           },
                         ),
                       );
@@ -514,15 +654,22 @@ class _GridOverlayState extends State<_GridOverlay> {
                 onPressed: () async {
                   final selected = await _openAssetPicker(sheetContext, ap);
                   if (selected == null) return;
-                  await sheetContext.read<AssetProvider>().setLocationAndSync(
-                        assetId: selected.id,
-                        drawingId: d.id,
-                        row: row,
-                        col: col,
-                        drawingProvider: dp,
-                      );
-                  if (sheetContext.mounted) Navigator.of(sheetContext).pop();
-                  _openCellDialog(context, dp.getById(d.id)!, row, col);
+                  try {
+                    await sheetContext.read<AssetProvider>().setLocationAndSync(
+                          assetId: selected.id,
+                          drawingId: d.id,
+                          row: areaRow,
+                          col: areaCol,
+                          drawingProvider: dp,
+                        );
+                    if (sheetContext.mounted) Navigator.of(sheetContext).pop();
+                    _openCellDialog(context, dp.getById(d.id)!, areaRow, areaCol);
+                  } on StateError catch (_) {
+                    if (!mounted) return;
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('다른 2×2 영역과 겹칠 수 없습니다.')),
+                    );
+                  }
                 },
                 icon: const Icon(Icons.add),
                 label: const Text('자산 추가'),
@@ -572,33 +719,45 @@ class _GridOverlayState extends State<_GridOverlay> {
 }
 
 class _AssetMarker extends StatelessWidget {
-  const _AssetMarker({required this.count, required this.onTap});
+  const _AssetMarker({
+    required this.count,
+    required this.onTap,
+    this.isDragging = false,
+  });
 
   final int count;
   final VoidCallback onTap;
+  final bool isDragging;
 
   @override
   Widget build(BuildContext context) {
+    final color = Colors.deepPurpleAccent.withOpacity(isDragging ? 0.6 : 0.9);
     return Material(
       color: Colors.transparent,
-      child: InkResponse(
+      child: InkWell(
         onTap: onTap,
-        radius: 22,
-        child: Container(
-          alignment: Alignment.center,
+        borderRadius: BorderRadius.circular(6),
+        child: Ink(
           decoration: BoxDecoration(
-            color: Colors.deepPurpleAccent.withOpacity(0.9),
-            shape: BoxShape.circle,
+            color: color,
+            borderRadius: BorderRadius.circular(6),
+            border: Border.all(color: Colors.white.withOpacity(0.9), width: 2),
             boxShadow: const [
-              BoxShadow(color: Colors.black26, blurRadius: 6, offset: Offset(0, 2)),
+              BoxShadow(color: Colors.black26, blurRadius: 8, offset: Offset(0, 3)),
             ],
           ),
-          child: FittedBox(
-            child: Padding(
-              padding: const EdgeInsets.all(6.0),
-              child: Text(
-                '$count',
-                style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+          child: Center(
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Padding(
+                padding: const EdgeInsets.all(6.0),
+                child: Text(
+                  '$count',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
               ),
             ),
           ),
@@ -606,6 +765,20 @@ class _AssetMarker extends StatelessWidget {
       ),
     );
   }
+}
+
+class _MarkerDragData {
+  _MarkerDragData({
+    required this.row,
+    required this.col,
+    required List<String> assetIds,
+  })  : assetIds = List<String>.unmodifiable(assetIds),
+        areaKey = cellKeyFrom(row: row, col: col);
+
+  final int row;
+  final int col;
+  final List<String> assetIds;
+  final String areaKey;
 }
 
 /// 비례 격자 페인터: canvasW/H를 열/행으로 균등 분할해서 선을 그림
@@ -682,12 +855,25 @@ class _CellTappableAreaProportional extends StatelessWidget {
           return; // 캔버스 밖 무시
         }
 
+        if (cols <= 0 || rows <= 0) {
+          return;
+        }
+
         final cellW = canvasW / cols;
         final cellH = canvasH / rows;
 
-        final c = (local.dx / cellW).floor().clamp(0, cols - 1);
-        final r = (local.dy / cellH).floor().clamp(0, rows - 1);
-        onCellTap(r, c);
+        int c = (local.dx / cellW).floor();
+        int r = (local.dy / cellH).floor();
+        c = c.clamp(0, cols - 1);
+        r = r.clamp(0, rows - 1);
+
+        final normalized = normalizeBlockOrigin(
+          row: r,
+          col: c,
+          rows: rows,
+          cols: cols,
+        );
+        onCellTap(normalized.$1, normalized.$2);
       },
     );
   }

--- a/lib/view/screen/asset_detail_screen.dart
+++ b/lib/view/screen/asset_detail_screen.dart
@@ -356,15 +356,22 @@ class _LocationDialogState extends State<_LocationDialog> {
           onPressed: () async {
             final r = int.tryParse(_row.text) ?? 0;
             final c = int.tryParse(_col.text) ?? 0;
-            await context.read<AssetProvider>().setLocationAndSync(
-              assetId: widget.assetId,
-              drawingId: _drawingId,
-              row: _drawingId == null ? null : r,
-              col: _drawingId == null ? null : c,
-              drawingFile: _file.text.isEmpty ? null : _file.text,
-              drawingProvider: context.read<DrawingProvider>(),
-            );
-            if (context.mounted) Navigator.pop(context);
+            try {
+              await context.read<AssetProvider>().setLocationAndSync(
+                    assetId: widget.assetId,
+                    drawingId: _drawingId,
+                    row: _drawingId == null ? null : r,
+                    col: _drawingId == null ? null : c,
+                    drawingFile: _file.text.isEmpty ? null : _file.text,
+                    drawingProvider: context.read<DrawingProvider>(),
+                  );
+              if (context.mounted) Navigator.pop(context);
+            } on StateError catch (_) {
+              if (!context.mounted) return;
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('다른 2×2 영역과 겹칠 수 없습니다.')),
+              );
+            }
           },
           child: const Text('저장'),
         ),

--- a/lib/view/screen/asset_edit_screen.dart
+++ b/lib/view/screen/asset_edit_screen.dart
@@ -130,16 +130,23 @@ class _LocationEditorState extends State<_LocationEditor> {
                 onPressed: () async {
                   final r = int.tryParse(_row.text) ?? 0;
                   final c = int.tryParse(_col.text) ?? 0;
-                  await context.read<AssetProvider>().setLocationAndSync(
-                    assetId: widget.assetId,
-                    drawingId: _drawingId,
-                    row: _drawingId == null ? null : r,
-                    col: _drawingId == null ? null : c,
-                    drawingProvider: context.read<DrawingProvider>(),
-                  );
-                  if (context.mounted) {
+                  try {
+                    await context.read<AssetProvider>().setLocationAndSync(
+                          assetId: widget.assetId,
+                          drawingId: _drawingId,
+                          row: _drawingId == null ? null : r,
+                          col: _drawingId == null ? null : c,
+                          drawingProvider: context.read<DrawingProvider>(),
+                        );
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('위치가 저장되었습니다.')),
+                      );
+                    }
+                  } on StateError catch (_) {
+                    if (!context.mounted) return;
                     ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('위치가 저장되었습니다.')),
+                      const SnackBar(content: Text('다른 2×2 영역과 겹칠 수 없습니다.')),
                     );
                   }
                 },


### PR DESCRIPTION
## Summary
- add shared grid marker helpers to normalize 2×2 marker positions and detect overlaps
- update repositories, providers, and the drawing map to render square 2×2 markers and support drag repositioning without overlaps
- adjust asset detail/edit flows to surface overlap errors when assigning markers

## Testing
- `flutter test` *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8b3ef68c83229e08ebae6aa82291