### PR TITLE
docs: add file metadata comments to screens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,8 @@
-// lib/main.dart
+// File Path: lib/main.dart
+// Features:
+// - main 함수 (13~15행): OAManagerApp을 실행합니다.
+// - OAManagerApp.build (21~55행): Provider를 초기화하고 MaterialApp.router를 구성합니다.
+// - addPostFrameCallback (33~41행): 자산 위치 정보를 DrawingProvider와 동기화합니다.
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'route/app_router.dart';

--- a/lib/view/drawing/drawing_map_screen.dart
+++ b/lib/view/drawing/drawing_map_screen.dart
@@ -1,4 +1,8 @@
-// lib/view/drawing/drawing_map_screen.dart
+// File Path: lib/view/drawing/drawing_map_screen.dart
+// Features:
+// - _DrawingMapScreenState.build (46~118행): 도면 정보 헤더, 배율 드롭다운, 캔버스 위젯을 배치합니다.
+// - _DrawingCanvas.build (235~245행): 선택된 도면과 자산 데이터를 _GridOverlay에 전달합니다.
+// - _GridOverlayState.build (352~520행): InteractiveViewer에서 배경, 격자, 마커 드래그/드롭을 처리합니다.
 import 'dart:ui' as ui; // 이미지 원본 크기 확인
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';

--- a/lib/view/drawing/drawing_screen.dart
+++ b/lib/view/drawing/drawing_screen.dart
@@ -1,4 +1,8 @@
-// lib/view/drawing/drawing_screen.dart
+// File Path: lib/view/drawing/drawing_screen.dart
+// Features:
+// - DrawingScreen.build (22~88행): DrawingProvider에서 도면 목록을 읽어 카드 리스트와 범례를 렌더링합니다.
+// - 열기 버튼 onPressed (65~69행): 도면 이미지를 로드한 뒤 '/drawing/:id/map' 라우트로 이동합니다.
+// - _Legend.build (97~116행): 배경 여부를 나타내는 간단한 범례 UI를 구성합니다.
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';

--- a/lib/view/screen/asset_detail_screen.dart
+++ b/lib/view/screen/asset_detail_screen.dart
@@ -1,4 +1,8 @@
-// lib/view/screen/asset_detail_screen.dart
+// File Path: lib/view/screen/asset_detail_screen.dart
+// Features:
+// - AssetDetailScreen.build (18~145행): Provider 데이터를 활용해 자산 상세 정보와 액션 버튼을 구성합니다.
+// - _AssetInfoDialogState.build (216~271행): 자산 필드 편집용 텍스트 입력 폼을 렌더링합니다.
+// - _LocationDialogState 저장 onPressed (356~377행): AssetProvider.setLocationAndSync로 위치를 저장합니다.
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';

--- a/lib/view/screen/asset_edit_screen.dart
+++ b/lib/view/screen/asset_edit_screen.dart
@@ -1,4 +1,8 @@
-// lib/view/screen/asset_edit_screen.dart
+// File Path: lib/view/screen/asset_edit_screen.dart
+// Features:
+// - AssetEditScreen.build (18~38행): 생성/수정 모드에 따라 안내 문구 또는 위치 편집기를 제공합니다.
+// - _LocationEditorState.build (67~195행): 도면 선택, 좌표 입력, 저장/해제 버튼 등 위치 편집 UI를 구성합니다.
+// - 저장 버튼 onPressed (134~155행): AssetProvider.setLocationAndSync 호출로 위치를 갱신하고 스낵바를 노출합니다.
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../provider/asset_provider.dart';

--- a/lib/view/screen/asset_list_screen.dart
+++ b/lib/view/screen/asset_list_screen.dart
@@ -1,4 +1,8 @@
-// lib/view/screen/asset_list_screen.dart
+// File Path: lib/view/screen/asset_list_screen.dart
+// Features:
+// - AssetListScreen.createState (15행): 상태를 보존하기 위해 StatefulWidget로 리스트 화면을 구성합니다.
+// - _AssetListScreenState.build (30~104행): AssetProvider 데이터를 필터링하고 검색/카테고리 UI를 그립니다.
+// - ListTile.onTap (93~96행): context.push('/asset/:id')로 자산 상세 화면을 엽니다.
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../provider/asset_provider.dart';

--- a/lib/view/screen/free_screen.dart
+++ b/lib/view/screen/free_screen.dart
@@ -1,3 +1,6 @@
+// File Path: lib/view/screen/free_screen.dart
+// Features:
+// - FreeScreen.build (8~10행): 자유게시판 샘플 문구를 중앙의 텍스트로 표시합니다.
 import 'package:flutter/material.dart';
 
 class FreeScreen extends StatelessWidget {

--- a/lib/view/screen/home_screen.dart
+++ b/lib/view/screen/home_screen.dart
@@ -1,3 +1,8 @@
+// File Path: lib/view/screen/home_screen.dart
+// Features:
+// - HomeScreen.build (16~39행): 홈 화면에 제목, 스캔 이동 버튼, 최근 스캔 기록 리스트를 배치합니다.
+// - 스캔 이동 버튼 onPressed (25행): go_router를 사용해 '/home/scan' 경로로 이동시킵니다.
+// - 최근 기록 출력부 (32~38행): ScanProvider.history 데이터를 최대 10개까지 표시합니다.
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';

--- a/lib/view/screen/login_screen.dart
+++ b/lib/view/screen/login_screen.dart
@@ -1,3 +1,7 @@
+// File Path: lib/view/screen/login_screen.dart
+// Features:
+// - LoginScreen.build (18~39행): 로그인 화면 스캐폴드를 구성하고 입력 필드와 버튼을 배치합니다.
+// - FilledButton.onPressed (27~33행): 사용자 이름을 검증해 UserProvider.login 호출 후 이전 화면으로 돌아갑니다.
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../provider/user_provider.dart';

--- a/lib/view/screen/member_screen.dart
+++ b/lib/view/screen/member_screen.dart
@@ -1,3 +1,7 @@
+// File Path: lib/view/screen/member_screen.dart
+// Features:
+// - MemberScreen.build (12~30행): 회원정보 스크린 스캐폴드를 구성하고 로그인 상태를 표시합니다.
+// - 로그아웃 버튼 onPressed (24행): 로그인 상태일 때 UserProvider.logout을 호출합니다.
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../provider/user_provider.dart';

--- a/lib/view/screen/news_screen.dart
+++ b/lib/view/screen/news_screen.dart
@@ -1,7 +1,11 @@
-// news_screen.dart
+// File Path: lib/view/screen/news_screen.dart
+// Features:
+// - NewsScreen.build (8~10행): 뉴스 목록 화면의 샘플 텍스트를 중앙에 렌더링합니다.
 import 'package:flutter/material.dart';
+
 class NewsScreen extends StatelessWidget {
   const NewsScreen({super.key});
+
   @override
   Widget build(BuildContext context) => const Center(child: Text('뉴스 목록 (샘플)'));
 }

--- a/lib/view/screen/notice_screen.dart
+++ b/lib/view/screen/notice_screen.dart
@@ -1,7 +1,11 @@
-// notice_screen.dart
+// File Path: lib/view/screen/notice_screen.dart
+// Features:
+// - NoticeScreen.build (8~10행): 공지/제휴 화면의 샘플 텍스트를 중앙에 표시합니다.
 import 'package:flutter/material.dart';
+
 class NoticeScreen extends StatelessWidget {
   const NoticeScreen({super.key});
+
   @override
   Widget build(BuildContext context) => const Center(child: Text('공지/제휴 (샘플)'));
 }

--- a/lib/view/screen/record_screen.dart
+++ b/lib/view/screen/record_screen.dart
@@ -1,3 +1,6 @@
+// File Path: lib/view/screen/record_screen.dart
+// Features:
+// - RecordScreen.build (8~10행): 기록/실험 화면의 더미 안내 문구를 중앙에 배치합니다.
 import 'package:flutter/material.dart';
 
 class RecordScreen extends StatelessWidget {

--- a/lib/view/screen/scan_screen.dart
+++ b/lib/view/screen/scan_screen.dart
@@ -1,3 +1,8 @@
+// File Path: lib/view/screen/scan_screen.dart
+// Features:
+// - _ScanScreenState.build (58~188행): 카메라 프리뷰, 마스킹, 컨트롤 오버레이, 최근 스캔 정보를 포함한 스캔 UI를 구성합니다.
+// - _onWillPop (40~43행): 하드웨어 뒤로가기 입력 시 스캐너를 정지하고 현재 라우트를 종료합니다.
+// - MobileScanner.onDetect (85~101행): 감지한 바코드를 ScanProvider.record로 저장하고 재감지를 제어합니다.
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';

--- a/lib/view/screen/settings_screen.dart
+++ b/lib/view/screen/settings_screen.dart
@@ -1,3 +1,6 @@
+// File Path: lib/view/screen/settings_screen.dart
+// Features:
+// - SettingsScreen.build (8~10행): 설정 화면의 샘플 안내 문구를 중앙 정렬합니다.
 import 'package:flutter/material.dart';
 
 class SettingsScreen extends StatelessWidget {


### PR DESCRIPTION
## Summary
- add header comments to the Flutter entry point and every screen/drawing file describing key functionality with line references

## Testing
- flutter analyze *(fails: Flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce66492bd88322989a79d81b043924