### PR TITLE
Adjust marker span configuration and movement

### DIFF
--- a/lib/model/drawing.dart
+++ b/lib/model/drawing.dart
@@ -6,7 +6,7 @@ import '../seed/grid_seed.dart';
 /// 도면 모델 (건물 · 층별)
 class Drawing {
   /// 마커가 차지하는 격자 크기 (행, 열)
-  static const int markerBlockSpan = 2;
+  static int get markerBlockSpan => GridSeed.markerBlockSpan;
 
   final String id;           // 고유 ID
   final String building;           // 건물명

--- a/lib/seed/grid_seed.dart
+++ b/lib/seed/grid_seed.dart
@@ -21,6 +21,7 @@ class GridSeed {
   static const double borderStrokeWidth = 2.0;
 
   /// ✅ 마커 스타일 (색상/투명도/테두리)
+  static const int markerBlockSpan = 2; // 마커가 차지하는 격자 크기 (행, 열)
   static const int markerColorHex = 0xFF7B61FF; // 기본 마커 배경색
   static const double markerOpacity = 1; // 일반 상태 불투명도
   static const double markerDraggingOpacity = 0.45; // 드래그 중 불투명도

--- a/lib/util/grid_marker.dart
+++ b/lib/util/grid_marker.dart
@@ -16,7 +16,7 @@ import '../model/drawing.dart';
   }
 }
 
-/// 주어진 위치를 마커 크기에 맞춰 정규화한 (row, col)을 반환합니다.
+/// 주어진 위치를 마커 크기를 고려해 경계 내로 정규화한 (row, col)을 반환합니다.
 /// - span 보다 작은 격자에서는 항상 (0,0)을 반환합니다.
 (int, int) normalizeBlockOrigin({
   required int row,
@@ -26,14 +26,14 @@ import '../model/drawing.dart';
   int span = Drawing.markerBlockSpan,
 }) {
   int _normalizeIndex(int value, int maxCount) {
-    if (maxCount <= span) {
+    final effectiveSpan = span <= 0 ? 1 : span;
+    if (maxCount <= effectiveSpan) {
       return 0;
     }
-    final maxStart = maxCount - span;
-    int clamped = value;
-    if (clamped < 0) clamped = 0;
-    if (clamped > maxStart) clamped = maxStart;
-    return (clamped ~/ span) * span;
+    final maxStart = maxCount - effectiveSpan;
+    if (value < 0) return 0;
+    if (value > maxStart) return maxStart;
+    return value;
   }
 
   return (_normalizeIndex(row, rows), _normalizeIndex(col, cols));

--- a/lib/view/drawing/drawing_map_screen.dart
+++ b/lib/view/drawing/drawing_map_screen.dart
@@ -590,6 +590,9 @@ class _GridOverlayState extends State<_GridOverlay> {
       return;
     }
 
+    final span = GridSeed.markerBlockSpan;
+    final overlapMessage = '다른 ${span}×$span 영역과 겹칠 수 없습니다.';
+
     double dx = scenePosition.dx;
     double dy = scenePosition.dy;
     if (dx.isNaN || dy.isNaN) {
@@ -637,7 +640,7 @@ class _GridOverlayState extends State<_GridOverlay> {
     if (!canPlace) {
       if (!mounted) return;
       ScaffoldMessenger.of(this.context).showSnackBar(
-        const SnackBar(content: Text('다른 2×2 영역과 겹칠 수 없습니다.')),
+        SnackBar(content: Text(overlapMessage)),
       );
       return;
     }
@@ -655,7 +658,7 @@ class _GridOverlayState extends State<_GridOverlay> {
     } on StateError catch (_) {
       if (!mounted) return;
       ScaffoldMessenger.of(this.context).showSnackBar(
-        const SnackBar(content: Text('다른 2×2 영역과 겹칠 수 없습니다.')),
+        SnackBar(content: Text(overlapMessage)),
       );
     }
   }
@@ -800,7 +803,11 @@ class _GridOverlayState extends State<_GridOverlay> {
                   } on StateError catch (_) {
                     if (!mounted) return;
                     ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('다른 2×2 영역과 겹칠 수 없습니다.')),
+                      SnackBar(
+                        content: Text(
+                          '다른 ${GridSeed.markerBlockSpan}×${GridSeed.markerBlockSpan} 영역과 겹칠 수 없습니다.',
+                        ),
+                      ),
                     );
                   }
                 },

--- a/lib/view/screen/asset_detail_screen.dart
+++ b/lib/view/screen/asset_detail_screen.dart
@@ -10,6 +10,7 @@ import '../../provider/asset_provider.dart';
 import '../../provider/drawing_provider.dart';
 import '../../util/drawing_image_loader.dart';
 import '../../model/asset.dart';
+import '../../seed/grid_seed.dart';
 
 String _fmtDate(DateTime? d) =>
     d == null ? '' : d.toIso8601String().split('T').first;
@@ -372,8 +373,9 @@ class _LocationDialogState extends State<_LocationDialog> {
               if (context.mounted) Navigator.pop(context);
             } on StateError catch (_) {
               if (!context.mounted) return;
+              final span = GridSeed.markerBlockSpan;
               ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('다른 2×2 영역과 겹칠 수 없습니다.')),
+                SnackBar(content: Text('다른 ${span}×$span 영역과 겹칠 수 없습니다.')),
               );
             }
           },

--- a/lib/view/screen/asset_edit_screen.dart
+++ b/lib/view/screen/asset_edit_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../provider/asset_provider.dart';
 import '../../provider/drawing_provider.dart';
+import '../../seed/grid_seed.dart';
 
 enum AssetEditMode { create, update }
 
@@ -149,8 +150,9 @@ class _LocationEditorState extends State<_LocationEditor> {
                     }
                   } on StateError catch (_) {
                     if (!context.mounted) return;
+                    final span = GridSeed.markerBlockSpan;
                     ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('다른 2×2 영역과 겹칠 수 없습니다.')),
+                      SnackBar(content: Text('다른 ${span}×$span 영역과 겹칠 수 없습니다.')),
                     );
                   }
                 },


### PR DESCRIPTION
## Summary
- centralize the marker block span configuration in `GridSeed` and expose it through `Drawing`
- allow marker normalization to clamp per cell so markers move in single-cell increments
- update overlap warning messages to reflect the configured marker size

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ce9f4341948322908ed7fd388e1682