### PR TITLE
Add asset registration and verification workflows after scanning

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:provider/provider.dart';
 import 'route/app_router.dart';
 import 'provider/drawing_provider.dart';
 import 'provider/asset_provider.dart';
+import 'provider/asset_verification_provider.dart';
 import 'provider/list_provider.dart';
 import 'provider/scan_provider.dart';
 
@@ -24,6 +25,7 @@ class OAManagerApp extends StatelessWidget {
       providers: [
         ChangeNotifierProvider(create: (_) => DrawingProvider()),
         ChangeNotifierProvider(create: (_) => AssetProvider()),
+        ChangeNotifierProvider(create: (_) => AssetVerificationProvider()),
         // 네비게이션 전환 시 게시판별 카운트를 갱신하는 ViewCountProvider
         ChangeNotifierProvider(create: (_) => ViewCountProvider()),
         ChangeNotifierProvider(create: (_) => ScanProvider()),

--- a/lib/model/asset_verification.dart
+++ b/lib/model/asset_verification.dart
@@ -1,0 +1,69 @@
+class AssetVerification {
+  final String id;
+  final String assetId;
+  final String assetNumber;
+  final String ownerName;
+  final String serialNumber;
+  final String assetCategory;
+  final String usageType;
+  final String modelName;
+  final String team;
+  final String building;
+  final String floor;
+  final String networkType;
+  final String usageDetail;
+  final String signature;
+  final DateTime verifiedAt;
+
+  AssetVerification({
+    required this.id,
+    required this.assetId,
+    required this.assetNumber,
+    required this.ownerName,
+    required this.serialNumber,
+    required this.assetCategory,
+    required this.usageType,
+    required this.modelName,
+    required this.team,
+    required this.building,
+    required this.floor,
+    required this.networkType,
+    required this.usageDetail,
+    required this.signature,
+    required this.verifiedAt,
+  });
+
+  AssetVerification copyWith({
+    String? assetNumber,
+    String? ownerName,
+    String? serialNumber,
+    String? assetCategory,
+    String? usageType,
+    String? modelName,
+    String? team,
+    String? building,
+    String? floor,
+    String? networkType,
+    String? usageDetail,
+    String? signature,
+    DateTime? verifiedAt,
+  }) {
+    return AssetVerification(
+      id: id,
+      assetId: assetId,
+      assetNumber: assetNumber ?? this.assetNumber,
+      ownerName: ownerName ?? this.ownerName,
+      serialNumber: serialNumber ?? this.serialNumber,
+      assetCategory: assetCategory ?? this.assetCategory,
+      usageType: usageType ?? this.usageType,
+      modelName: modelName ?? this.modelName,
+      team: team ?? this.team,
+      building: building ?? this.building,
+      floor: floor ?? this.floor,
+      networkType: networkType ?? this.networkType,
+      usageDetail: usageDetail ?? this.usageDetail,
+      signature: signature ?? this.signature,
+      verifiedAt: verifiedAt ?? this.verifiedAt,
+    );
+  }
+}

--- a/lib/provider/asset_provider.dart
+++ b/lib/provider/asset_provider.dart
@@ -16,9 +16,46 @@ class AssetProvider extends ChangeNotifier {
 
   Asset? getById(String id) => repo.getById(id);
 
+  Asset? getByCode(String code) => repo.getByCode(code);
+
   void reload() {
     items = repo.list();
     notifyListeners();
+  }
+
+  Asset createAsset({
+    required String code,
+    required String name,
+    required String category,
+    required String serialNumber,
+    required String modelName,
+    required String vendor,
+    String? network,
+    String? normalComment,
+    String? oaComment,
+    String? macAddress,
+    String? building,
+    String? floor,
+    String? memberName,
+  }) {
+    final asset = repo.createFromSchema(
+      code: code,
+      name: name,
+      category: category,
+      serialNumber: serialNumber,
+      modelName: modelName,
+      vendor: vendor,
+      network: network,
+      normalComment: normalComment,
+      oaComment: oaComment,
+      macAddress: macAddress,
+      building: building,
+      floor: floor,
+      memberName: memberName,
+    );
+    items = repo.list();
+    notifyListeners();
+    return asset;
   }
 
   Asset? updateAsset(Asset asset) {

--- a/lib/provider/asset_verification_provider.dart
+++ b/lib/provider/asset_verification_provider.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+import '../model/asset_verification.dart';
+import '../repository/asset_verification_repository.dart';
+
+class AssetVerificationProvider extends ChangeNotifier {
+  final AssetVerificationRepository repo = AssetVerificationRepository();
+
+  List<AssetVerification> items = [];
+
+  AssetVerificationProvider() {
+    items = repo.list();
+  }
+
+  AssetVerification? getByAssetId(String assetId) => repo.getByAssetId(assetId);
+
+  AssetVerification saveVerification({
+    required String assetId,
+    required String assetNumber,
+    required String ownerName,
+    required String serialNumber,
+    required String assetCategory,
+    required String usageType,
+    required String modelName,
+    required String team,
+    required String building,
+    required String floor,
+    required String networkType,
+    required String usageDetail,
+    required String signature,
+  }) {
+    final saved = repo.save(
+      assetId: assetId,
+      assetNumber: assetNumber,
+      ownerName: ownerName,
+      serialNumber: serialNumber,
+      assetCategory: assetCategory,
+      usageType: usageType,
+      modelName: modelName,
+      team: team,
+      building: building,
+      floor: floor,
+      networkType: networkType,
+      usageDetail: usageDetail,
+      signature: signature,
+    );
+    items = repo.list();
+    notifyListeners();
+    return saved;
+  }
+}

--- a/lib/repository/asset_repository.dart
+++ b/lib/repository/asset_repository.dart
@@ -18,9 +18,55 @@ class AssetRepository {
 
   Asset? getById(String id) => _items.where((e) => e.id == id).firstOrNull;
 
+  Asset? getByCode(String code) =>
+      _items.where((e) => e.code.toLowerCase() == code.toLowerCase()).firstOrNull;
+
   Asset create(Asset a) {
     _items.insert(0, a);
     return a;
+  }
+
+  Asset createFromSchema({
+    required String code,
+    required String name,
+    required String category,
+    required String serialNumber,
+    required String modelName,
+    required String vendor,
+    String? network,
+    String? normalComment,
+    String? oaComment,
+    String? macAddress,
+    String? building,
+    String? floor,
+    String? memberName,
+  }) {
+    final now = DateTime.now();
+    final asset = Asset(
+      id: _nextId(),
+      code: code,
+      name: name,
+      category: category,
+      serialNumber: serialNumber,
+      modelName: modelName,
+      vendor: vendor,
+      network: network,
+      physicalCheckDate: null,
+      confirmationDate: null,
+      normalComment: normalComment,
+      oaComment: oaComment,
+      macAddress: macAddress,
+      building: building,
+      floor: floor,
+      memberName: memberName,
+      locationDrawingId: null,
+      locationRow: null,
+      locationCol: null,
+      locationDrawingFile: null,
+      createdAt: now,
+      updatedAt: now,
+    );
+    return create(asset);
   }
 
   Asset? update(Asset a) {
@@ -53,6 +99,11 @@ class AssetRepository {
 
   // ───────────────────────────────────────────────────────────
   // Seed & Helpers
+
+  String _nextId() {
+    _idCounter += 1;
+    return _idCounter.toString();
+  }
 
   void _seed20() {
     final rnd = Random();
@@ -106,12 +157,6 @@ class AssetRepository {
     String _mac() {
       String hex() => rnd.nextInt(256).toRadixString(16).padLeft(2, '0');
       return '${hex()}-${hex()}-${hex()}-${hex()}-${hex()}-${hex()}';
-    }
-
-    // 오름차순 id 생성 ("1","2","3"...)
-    String _nextId() {
-      _idCounter += 1;
-      return _idCounter.toString();
     }
 
     // 기본 10개 프리셋

--- a/lib/repository/asset_verification_repository.dart
+++ b/lib/repository/asset_verification_repository.dart
@@ -1,0 +1,77 @@
+import '../model/asset_verification.dart';
+
+class AssetVerificationRepository {
+  final List<AssetVerification> _items = [];
+  int _idCounter = 0;
+
+  List<AssetVerification> list() => List.unmodifiable(_items);
+
+  AssetVerification? getByAssetId(String assetId) =>
+      _items.where((e) => e.assetId == assetId).firstOrNull;
+
+  AssetVerification save({
+    required String assetId,
+    required String assetNumber,
+    required String ownerName,
+    required String serialNumber,
+    required String assetCategory,
+    required String usageType,
+    required String modelName,
+    required String team,
+    required String building,
+    required String floor,
+    required String networkType,
+    required String usageDetail,
+    required String signature,
+  }) {
+    final now = DateTime.now();
+    final idx = _items.indexWhere((element) => element.assetId == assetId);
+    if (idx >= 0) {
+      _items[idx] = _items[idx].copyWith(
+        assetNumber: assetNumber,
+        ownerName: ownerName,
+        serialNumber: serialNumber,
+        assetCategory: assetCategory,
+        usageType: usageType,
+        modelName: modelName,
+        team: team,
+        building: building,
+        floor: floor,
+        networkType: networkType,
+        usageDetail: usageDetail,
+        signature: signature,
+        verifiedAt: now,
+      );
+      return _items[idx];
+    }
+
+    final entry = AssetVerification(
+      id: _nextId(),
+      assetId: assetId,
+      assetNumber: assetNumber,
+      ownerName: ownerName,
+      serialNumber: serialNumber,
+      assetCategory: assetCategory,
+      usageType: usageType,
+      modelName: modelName,
+      team: team,
+      building: building,
+      floor: floor,
+      networkType: networkType,
+      usageDetail: usageDetail,
+      signature: signature,
+      verifiedAt: now,
+    );
+    _items.add(entry);
+    return entry;
+  }
+
+  String _nextId() {
+    _idCounter += 1;
+    return _idCounter.toString();
+  }
+}
+
+extension FirstOrNullExtension<E> on Iterable<E> {
+  E? get firstOrNull => isEmpty ? null : first;
+}

--- a/lib/route/app_router.dart
+++ b/lib/route/app_router.dart
@@ -13,6 +13,8 @@ import '../view/screen/settings_screen.dart';
 import '../view/screen/login_screen.dart';
 import '../view/screen/member_screen.dart';
 import '../view/screen/scan_screen.dart';
+import '../view/screen/assets_signup_screen.dart';
+import '../view/screen/asset_verification_screen.dart';
 
 // 자산(게시판)
 import '../view/screen/asset_list_screen.dart';
@@ -171,6 +173,24 @@ final appRouter = GoRouter(
       ],
     ),
     // 공용
+    GoRoute(
+      path: '/news/assetsSignUp',
+      pageBuilder: (context, state) => NoTransitionPage(
+        child: ShellScaffold(
+          body: AssetsSignUpScreen(initialCode: state.uri.queryParameters['code']),
+        ),
+      ),
+    ),
+    GoRoute(
+      path: '/notice/assetVerification/:assetId',
+      pageBuilder: (context, state) => NoTransitionPage(
+        child: ShellScaffold(
+          body: AssetVerificationScreen(
+            assetId: state.pathParameters['assetId']!,
+          ),
+        ),
+      ),
+    ),
     GoRoute(path: '/login', builder: (context, state) => const LoginScreen()),
     GoRoute(path: '/member', builder: (context, state) => const MemberScreen()),
   ],

--- a/lib/view/screen/asset_verification_screen.dart
+++ b/lib/view/screen/asset_verification_screen.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../provider/asset_provider.dart';
+import '../../provider/asset_verification_provider.dart';
+
+class AssetVerificationScreen extends StatefulWidget {
+  const AssetVerificationScreen({super.key, required this.assetId});
+
+  final String assetId;
+
+  @override
+  State<AssetVerificationScreen> createState() => _AssetVerificationScreenState();
+}
+
+class _AssetVerificationScreenState extends State<AssetVerificationScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _assetNumber = TextEditingController();
+  final _ownerName = TextEditingController();
+  final _serialNumber = TextEditingController();
+  final _assetCategory = TextEditingController();
+  final _usageType = TextEditingController();
+  final _modelName = TextEditingController();
+  final _team = TextEditingController();
+  final _building = TextEditingController();
+  final _floor = TextEditingController();
+  final _networkType = TextEditingController();
+  final _usageDetail = TextEditingController();
+  final _signature = TextEditingController();
+
+  DateTime? _lastVerifiedAt;
+  bool _initialized = false;
+
+  @override
+  void dispose() {
+    _assetNumber.dispose();
+    _ownerName.dispose();
+    _serialNumber.dispose();
+    _assetCategory.dispose();
+    _usageType.dispose();
+    _modelName.dispose();
+    _team.dispose();
+    _building.dispose();
+    _floor.dispose();
+    _networkType.dispose();
+    _usageDetail.dispose();
+    _signature.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_initialized) return;
+    final asset = context.read<AssetProvider>().getById(widget.assetId);
+    final verification =
+        context.read<AssetVerificationProvider>().getByAssetId(widget.assetId);
+    if (asset != null) {
+      _assetNumber.text = asset.code;
+      _ownerName.text = asset.memberName ?? '';
+      _serialNumber.text = asset.serialNumber;
+      _assetCategory.text = asset.category;
+      _modelName.text = asset.modelName;
+      _building.text = asset.building ?? '';
+      _floor.text = asset.floor ?? '';
+      _networkType.text = asset.network ?? '';
+    }
+    if (verification != null) {
+      _usageType.text = verification.usageType;
+      _team.text = verification.team;
+      _usageDetail.text = verification.usageDetail;
+      _signature.text = verification.signature;
+      _lastVerifiedAt = verification.verifiedAt;
+    }
+    _initialized = true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final asset = context.watch<AssetProvider>().getById(widget.assetId);
+    if (asset == null) {
+      return const Center(child: Text('자산 정보를 찾을 수 없습니다.'));
+    }
+
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Form(
+        key: _formKey,
+        child: ListView(
+          children: [
+            Text('실물 확인', style: Theme.of(context).textTheme.headlineSmall),
+            const SizedBox(height: 8),
+            Text('자산코드 ${asset.code}에 대한 실물 확인 및 최종 사용자 서명을 수집합니다.'),
+            if (_lastVerifiedAt != null) ...[
+              const SizedBox(height: 8),
+              Text('최근 확인일: ${_formatDate(_lastVerifiedAt!)}',
+                  style: const TextStyle(color: Colors.green)),
+            ],
+            const SizedBox(height: 24),
+            _buildTable(),
+            const SizedBox(height: 24),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton.icon(
+                onPressed: _save,
+                icon: const Icon(Icons.fact_check),
+                label: const Text('실물 확인 저장'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTable() {
+    return Table(
+      border: TableBorder.all(color: Colors.grey.shade300),
+      columnWidths: const {
+        0: IntrinsicColumnWidth(),
+        1: FlexColumnWidth(),
+      },
+      defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+      children: [
+        _tableRow('자산번호', _assetNumber, readOnly: true),
+        _tableRow('소유자명', _ownerName),
+        _tableRow('S/N', _serialNumber, readOnly: true),
+        _tableRow('자산종류', _assetCategory, readOnly: true),
+        _tableRow('사용용도(개인/공용)', _usageType,
+            hintText: '예) 개인', validator: _requiredValidator),
+        _tableRow('모델명', _modelName, readOnly: true),
+        _tableRow('팀', _team, hintText: '예) 생산기술팀'),
+        _tableRow('설치건물', _building),
+        _tableRow('설치 층', _floor),
+        _tableRow('네트워크구분', _networkType),
+        _tableRow('용도상세', _usageDetail,
+            hintText: '예) 회의실 화상회의 장비', validator: _requiredValidator),
+        _tableRow('최종 사용자 서명', _signature,
+            hintText: '서명 또는 이름을 입력해주세요', validator: _requiredValidator),
+      ],
+    );
+  }
+
+  TableRow _tableRow(String label, TextEditingController controller,
+      {bool readOnly = false,
+      String? hintText,
+      String? Function(String?)? validator}) {
+    return TableRow(
+      children: [
+        Container(
+          color: Colors.grey.shade100,
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 14),
+          child: Text(label, style: const TextStyle(fontWeight: FontWeight.w600)),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: TextFormField(
+            controller: controller,
+            readOnly: readOnly,
+            decoration: InputDecoration(
+              hintText: hintText,
+              border: InputBorder.none,
+            ),
+            validator: validator,
+          ),
+        ),
+      ],
+    );
+  }
+
+  String? _requiredValidator(String? value) {
+    if (value == null || value.trim().isEmpty) {
+      return '필수 입력 항목입니다.';
+    }
+    return null;
+  }
+
+  void _save() {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+    final verificationProvider = context.read<AssetVerificationProvider>();
+    verificationProvider.saveVerification(
+      assetId: widget.assetId,
+      assetNumber: _assetNumber.text.trim(),
+      ownerName: _ownerName.text.trim(),
+      serialNumber: _serialNumber.text.trim(),
+      assetCategory: _assetCategory.text.trim(),
+      usageType: _usageType.text.trim(),
+      modelName: _modelName.text.trim(),
+      team: _team.text.trim(),
+      building: _building.text.trim(),
+      floor: _floor.text.trim(),
+      networkType: _networkType.text.trim(),
+      usageDetail: _usageDetail.text.trim(),
+      signature: _signature.text.trim(),
+    );
+    setState(() {
+      _lastVerifiedAt = DateTime.now();
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('실물 확인 정보가 저장되었습니다.')),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')} ${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}';
+  }
+}

--- a/lib/view/screen/assets_signup_screen.dart
+++ b/lib/view/screen/assets_signup_screen.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../provider/asset_provider.dart';
+
+class AssetsSignUpScreen extends StatefulWidget {
+  const AssetsSignUpScreen({super.key, this.initialCode});
+
+  final String? initialCode;
+
+  @override
+  State<AssetsSignUpScreen> createState() => _AssetsSignUpScreenState();
+}
+
+class _AssetsSignUpScreenState extends State<AssetsSignUpScreen> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _code;
+  final _name = TextEditingController();
+  final _category = TextEditingController();
+  final _serial = TextEditingController();
+  final _modelName = TextEditingController();
+  final _vendor = TextEditingController();
+  final _network = TextEditingController();
+  final _building = TextEditingController();
+  final _floor = TextEditingController();
+  final _memberName = TextEditingController();
+  final _normalComment = TextEditingController();
+  final _oaComment = TextEditingController();
+  final _macAddress = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _code = TextEditingController(text: widget.initialCode ?? '');
+  }
+
+  @override
+  void dispose() {
+    _code.dispose();
+    _name.dispose();
+    _category.dispose();
+    _serial.dispose();
+    _modelName.dispose();
+    _vendor.dispose();
+    _network.dispose();
+    _building.dispose();
+    _floor.dispose();
+    _memberName.dispose();
+    _normalComment.dispose();
+    _oaComment.dispose();
+    _macAddress.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Form(
+        key: _formKey,
+        child: ListView(
+          children: [
+            Text('자산 등록', style: Theme.of(context).textTheme.headlineSmall),
+            const SizedBox(height: 8),
+            const Text('바코드 스캔 후 신규 자산을 등록합니다. 모든 필드를 가능한 정확히 입력해주세요.'),
+            const SizedBox(height: 24),
+            _buildTextField(
+              controller: _code,
+              label: '자산 코드',
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return '자산 코드를 입력해주세요.';
+                }
+                return null;
+              },
+            ),
+            _buildTextField(
+              controller: _name,
+              label: '자산명',
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return '자산명을 입력해주세요.';
+                }
+                return null;
+              },
+            ),
+            _buildTextField(
+              controller: _category,
+              label: '자산 분류',
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return '자산 분류를 입력해주세요.';
+                }
+                return null;
+              },
+            ),
+            _buildTextField(
+              controller: _serial,
+              label: 'S/N',
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return '시리얼 번호를 입력해주세요.';
+                }
+                return null;
+              },
+            ),
+            _buildTextField(
+              controller: _modelName,
+              label: '모델명',
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return '모델명을 입력해주세요.';
+                }
+                return null;
+              },
+            ),
+            _buildTextField(
+              controller: _vendor,
+              label: '제조사/공급사',
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return '제조사 또는 공급사를 입력해주세요.';
+                }
+                return null;
+              },
+            ),
+            _buildTextField(controller: _network, label: '네트워크 구분'),
+            _buildTextField(controller: _building, label: '설치 건물'),
+            _buildTextField(controller: _floor, label: '설치 층'),
+            _buildTextField(controller: _memberName, label: '담당자/소유자'),
+            _buildTextField(controller: _normalComment, label: '일반 비고', maxLines: 3),
+            _buildTextField(controller: _oaComment, label: 'OA 비고', maxLines: 3),
+            _buildTextField(controller: _macAddress, label: 'MAC 주소'),
+            const SizedBox(height: 24),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton.icon(
+                onPressed: _submit,
+                icon: const Icon(Icons.save),
+                label: const Text('자산 등록'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTextField({
+    required TextEditingController controller,
+    required String label,
+    int maxLines = 1,
+    String? Function(String?)? validator,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: TextFormField(
+        controller: controller,
+        maxLines: maxLines,
+        decoration: InputDecoration(labelText: label),
+        validator: validator,
+      ),
+    );
+  }
+
+  void _submit() {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+    final provider = context.read<AssetProvider>();
+    final code = _code.text.trim();
+    if (provider.getByCode(code) != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('이미 등록된 코드입니다: $code')),
+      );
+      return;
+    }
+
+    provider.createAsset(
+      code: code,
+      name: _name.text.trim(),
+      category: _category.text.trim(),
+      serialNumber: _serial.text.trim(),
+      modelName: _modelName.text.trim(),
+      vendor: _vendor.text.trim(),
+      network: _network.text.trim().isEmpty ? null : _network.text.trim(),
+      building: _building.text.trim().isEmpty ? null : _building.text.trim(),
+      floor: _floor.text.trim().isEmpty ? null : _floor.text.trim(),
+      memberName: _memberName.text.trim().isEmpty ? null : _memberName.text.trim(),
+      normalComment:
+          _normalComment.text.trim().isEmpty ? null : _normalComment.text.trim(),
+      oaComment: _oaComment.text.trim().isEmpty ? null : _oaComment.text.trim(),
+      macAddress: _macAddress.text.trim().isEmpty ? null : _macAddress.text.trim(),
+    );
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('자산이 등록되었습니다. (코드: $code)')),
+    );
+    _formKey.currentState!.reset();
+    _name.clear();
+    _category.clear();
+    _serial.clear();
+    _modelName.clear();
+    _vendor.clear();
+    _network.clear();
+    _building.clear();
+    _floor.clear();
+    _memberName.clear();
+    _normalComment.clear();
+    _oaComment.clear();
+    _macAddress.clear();
+  }
+}

--- a/lib/view/widget/scanned_footer.dart
+++ b/lib/view/widget/scanned_footer.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../../provider/scan_provider.dart';
 import 'package:go_router/go_router.dart';
+import '../../provider/asset_provider.dart';
+import '../../provider/scan_provider.dart';
 
 /// 전역 하단에 최근 스캔 결과를 고정 표시해주는 푸터
 class ScannedFooter extends StatelessWidget {
@@ -11,6 +12,8 @@ class ScannedFooter extends StatelessWidget {
   Widget build(BuildContext context) {
     final scan = context.watch<ScanProvider>();
     final code = scan.lastCode;
+    final assetProvider = context.watch<AssetProvider>();
+    final asset = code == null ? null : assetProvider.getByCode(code);
 
     return Material(
       elevation: 8,
@@ -24,6 +27,25 @@ class ScannedFooter extends StatelessWidget {
               icon: const Icon(Icons.qr_code_scanner),
               label: const Text('QR/바코드 스캔하기'),
             ),
+            if (code != null) ...[
+              const SizedBox(width: 12),
+              if (asset == null)
+                FilledButton.icon(
+                  onPressed: () {
+                    final encoded = Uri.encodeComponent(code);
+                    context.go('/news/assetsSignUp?code=$encoded');
+                  },
+                  icon: const Icon(Icons.playlist_add),
+                  label: const Text('자산 등록'),
+                )
+              else
+                FilledButton.icon(
+                  onPressed: () =>
+                      context.go('/notice/assetVerification/${asset.id}'),
+                  icon: const Icon(Icons.fact_check),
+                  label: const Text('실물 확인'),
+                ),
+            ],
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- show context-aware registration or verification actions in the scan footer
- add an asset registration form and verification workflow with supporting data stores
- wire new routes and providers so scan results can launch the appropriate flow

## Testing
- `flutter test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d432846d5c8322add0b81ab963011e