### PR TITLE
Update asset list to single-line summary

### DIFF
--- a/lib/view/screen/asset_list_screen.dart
+++ b/lib/view/screen/asset_list_screen.dart
@@ -85,10 +85,32 @@ class _AssetListScreenState extends State<AssetListScreen> {
                       final locText = hasLoc
                           ? '위치: ${a.building ?? ''}, ${a.floor ?? ''} (${a.locationRow}, ${a.locationCol})'
                           : '위치: 미지정';
+                      final info = [
+                        '코드: ${a.code}',
+                        '명칭: ${a.name}',
+                        '분류: ${a.category}',
+                        if ((a.memberName ?? '').trim().isNotEmpty)
+                          '사용자: ${a.memberName!.trim()}',
+                        '제조사: ${a.vendor}',
+                        '모델: ${a.modelName}',
+                        if ((a.network ?? '').trim().isNotEmpty)
+                          '네트워크: ${a.network!.trim()}',
+                        if ((a.building ?? '').trim().isNotEmpty)
+                          '건물: ${a.building!.trim()}',
+                        if ((a.floor ?? '').trim().isNotEmpty)
+                          '층: ${a.floor!.trim()}',
+                        if ((a.normalComment ?? '').trim().isNotEmpty)
+                          '비고: ${a.normalComment!.trim()}',
+                        locText,
+                      ];
+
                       return ListTile(
                         leading: const Icon(Icons.inventory_2),
-                        title: Text(a.name),
-                        subtitle: Text('코드: ${a.code}  ·  분류: ${a.category}  ·  $locText'),
+                        title: Text(
+                          info.join('  ·  '),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
                         trailing: const Icon(Icons.chevron_right),
                         onTap: () {
                           // 상세로 이동: /asset/:id (app_router에 이미 정의)


### PR DESCRIPTION
## Summary
- collapse the asset list tiles into a single-line summary string including key fields

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5305929f48322ab954d225a9f8c45